### PR TITLE
feat(types): add TopicState and TopicDisplay enums

### DIFF
--- a/App/Client/Basis.swift
+++ b/App/Client/Basis.swift
@@ -912,6 +912,52 @@ enum EpisodeCollectionType: Int, Codable, Identifiable, CaseIterable {
   }
 }
 
+enum TopicDisplay: Int, Codable, CaseIterable {
+  case ban = 0
+  case normal = 1
+  case review = 2
+
+  var description: String {
+    switch self {
+    case .ban:
+      return "已隐藏"
+    case .normal:
+      return "正常"
+    case .review:
+      return "审核中"
+    }
+  }
+}
+
+enum TopicState: Int, Codable, CaseIterable {
+  case normal = 0
+  case closed = 1
+  case reopen = 2
+  case silent = 5
+
+  var allowReply: Bool {
+    switch self {
+    case .normal, .reopen:
+      return true
+    case .closed, .silent:
+      return false
+    }
+  }
+
+  var description: String {
+    switch self {
+    case .normal:
+      return "正常"
+    case .closed:
+      return "已关闭"
+    case .reopen:
+      return "已重开"
+    case .silent:
+      return "已下沉"
+    }
+  }
+}
+
 enum PostState: Int, Codable, CaseIterable {
   case normal = 0
   case adminCloseTopic = 1

--- a/App/Client/Types.swift
+++ b/App/Client/Types.swift
@@ -289,8 +289,8 @@ struct TopicDTO: Codable, Identifiable, Hashable {
   var creator: SlimUserDTO?
   var title: String
   var replyCount: Int?
-  var state: Int
-  var display: Int
+  var state: TopicState
+  var display: TopicDisplay
   var createdAt: Int
   var updatedAt: Int
 }
@@ -303,8 +303,8 @@ struct SubjectTopicDTO: Codable, Identifiable, Hashable, Linkable {
   var subject: SlimSubjectDTO
   var title: String
   var replyCount: Int
-  var state: Int
-  var display: Int
+  var state: TopicState
+  var display: TopicDisplay
   var createdAt: Int
   var updatedAt: Int
   var replies: [ReplyDTO]
@@ -336,8 +336,8 @@ struct GroupTopicDTO: Codable, Identifiable, Hashable, Linkable {
   var group: SlimGroupDTO
   var title: String
   var replyCount: Int
-  var state: Int
-  var display: Int
+  var state: TopicState
+  var display: TopicDisplay
   var createdAt: Int
   var updatedAt: Int
   var replies: [ReplyDTO]

--- a/App/Components/MainPostActionButtons.swift
+++ b/App/Components/MainPostActionButtons.swift
@@ -8,6 +8,7 @@ struct MainPostActionButtons: View {
   let reactionType: ReactionType
   @Binding var reactions: [ReactionDTO]
   let maxReplyCount: Int
+  var allowReply: Bool = true
 
   var body: some View {
     HStack {
@@ -27,7 +28,7 @@ struct MainPostActionButtons: View {
         }
         .labelStyle(.compact)
       }
-      .disabled(!isAuthenticated)
+      .disabled(!isAuthenticated || !allowReply)
 
       Button {
         onIndex()

--- a/App/Views/Group/GroupTopicDetailView.swift
+++ b/App/Views/Group/GroupTopicDetailView.swift
@@ -147,7 +147,8 @@ struct GroupTopicDetailView: View {
                   onIndex: { showIndexPicker = true },
                   reactionType: .groupReply(mainPost.id),
                   reactions: $mainPostReactions,
-                  maxReplyCount: maxReplyCount
+                  maxReplyCount: maxReplyCount,
+                  allowReply: topic.state.allowReply
                 )
               }
             }
@@ -288,7 +289,7 @@ struct GroupTopicDetailView: View {
           } label: {
             Label("回复", systemImage: "plus.bubble")
           }
-          .disabled(!isAuthenticated)
+          .disabled(!isAuthenticated || !(topic?.state.allowReply ?? true))
           Button {
             showIndexPicker = true
           } label: {

--- a/App/Views/Subject/SubjectTopicDetailView.swift
+++ b/App/Views/Subject/SubjectTopicDetailView.swift
@@ -149,7 +149,8 @@ struct SubjectTopicDetailView: View {
                   onIndex: { showIndexPicker = true },
                   reactionType: .subjectReply(mainPost.id),
                   reactions: $mainPostReactions,
-                  maxReplyCount: maxReplyCount
+                  maxReplyCount: maxReplyCount,
+                  allowReply: topic.state.allowReply
                 )
               }
             }
@@ -290,7 +291,7 @@ struct SubjectTopicDetailView: View {
           } label: {
             Label("回复", systemImage: "plus.bubble")
           }
-          .disabled(!isAuthenticated)
+          .disabled(!isAuthenticated || !(topic?.state.allowReply ?? true))
           Button {
             showIndexPicker = true
           } label: {


### PR DESCRIPTION
- Add TopicDisplay enum (ban/normal/review) for topic visibility
- Add TopicState enum (normal/closed/reopen/silent) with allowReply property
- Update TopicDTO, SubjectTopicDTO, GroupTopicDTO to use typed enums
- Disable reply button in detail views when topic is closed/silent