### PR TITLE
feat: add iOS 18+ zoom transition for image navigation

### DIFF
--- a/App/Helpers/ImageNavConfig.swift
+++ b/App/Helpers/ImageNavConfig.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+// MARK: - Zoom Navigation ID
+
+/// Unique identifier for zoom navigation source/destination matching
+struct ZoomNavigationID: Hashable {
+  let type: ZoomNavigationType
+  let id: Int
+
+  enum ZoomNavigationType: String {
+    case subject
+    case character
+    case person
+  }
+}
+
+// MARK: - Environment Key for Shared Namespace
+
+private struct ZoomNamespaceKey: EnvironmentKey {
+  static let defaultValue: Namespace.ID? = nil
+}
+
+extension EnvironmentValues {
+  var zoomNamespace: Namespace.ID? {
+    get { self[ZoomNamespaceKey.self] }
+    set { self[ZoomNamespaceKey.self] = newValue }
+  }
+}
+
+// MARK: - Shared Namespace Provider
+
+/// Provides a shared namespace for zoom transitions within a NavigationStack
+struct ZoomTransitionContainer<Content: View>: View {
+  @Namespace private var namespace
+  let content: Content
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    content
+      .environment(\.zoomNamespace, namespace)
+  }
+}
+
+// MARK: - imageNavLink Modifier
+
+@available(iOS 18.0, *)
+private struct ImageNavLinkModifier: ViewModifier {
+  let link: String?
+
+  @Environment(\.zoomNamespace) private var namespace
+
+  func body(content: Content) -> some View {
+    if let link = link,
+      let url = URL(string: link),
+      let (destination, zoomID) = parseChiiLink(url)
+    {
+      if let namespace = namespace {
+        NavigationLink(value: destination) {
+          content
+        }
+        .buttonStyle(.plain)
+        .matchedTransitionSource(id: zoomID, in: namespace)
+      } else {
+        NavigationLink(value: destination) {
+          content
+        }
+        .buttonStyle(.plain)
+      }
+    } else if let link = link, let url = URL(string: link) {
+      Link(destination: url) {
+        content
+      }.buttonStyle(.plain)
+    } else {
+      content
+    }
+  }
+
+  private func parseChiiLink(_ url: URL) -> (NavDestination, ZoomNavigationID)? {
+    guard url.scheme == "chii" else { return nil }
+
+    let components = url.pathComponents.dropFirst()
+    switch url.host {
+    case "subject":
+      if let idStr = components.first, let id = Int(idStr) {
+        return (.subject(id), ZoomNavigationID(type: .subject, id: id))
+      }
+    case "character":
+      if let idStr = components.first, let id = Int(idStr) {
+        return (.character(id), ZoomNavigationID(type: .character, id: id))
+      }
+    case "person":
+      if let idStr = components.first, let id = Int(idStr) {
+        return (.person(id), ZoomNavigationID(type: .person, id: id))
+      }
+    default:
+      break
+    }
+    return nil
+  }
+}
+
+// MARK: - View Extension
+
+extension View {
+  /// NavigationLink-based image navigation with iOS 18+ zoom transition support.
+  /// Falls back to regular Link on older iOS versions.
+  @ViewBuilder
+  func imageNavLink(_ link: String?) -> some View {
+    if #available(iOS 18.0, *) {
+      self.modifier(ImageNavLinkModifier(link: link))
+    } else {
+      self.imageLink(link)
+    }
+  }
+}
+
+// MARK: - Zoom Transition Modifier for Destination Views
+
+/// Applies navigationTransition(.zoom) to destination views on iOS 18+
+struct ZoomTransitionModifier: ViewModifier {
+  let zoomID: ZoomNavigationID
+
+  @Environment(\.zoomNamespace) private var namespace
+
+  func body(content: Content) -> some View {
+    if #available(iOS 18.0, *), let namespace = namespace {
+      content
+        .navigationTransition(.zoom(sourceID: zoomID, in: namespace))
+    } else {
+      content
+    }
+  }
+}

--- a/App/Views/Character/CharacterCastItemView.swift
+++ b/App/Views/Character/CharacterCastItemView.swift
@@ -14,7 +14,7 @@ struct CharacterCastItemView: View {
           .imageCaption {
             Text(item.type.description)
           }
-          .imageLink(item.subject.link)
+          .imageNavLink(item.subject.link)
 
         VStack(alignment: .leading) {
           Text(item.subject.title(with: titlePreference).withLink(item.subject.link))
@@ -48,7 +48,7 @@ struct CharacterCastItemView: View {
               ImageView(img: person.images?.grid)
                 .imageStyle(width: 40, height: 40, alignment: .top)
                 .imageType(.person)
-                .imageLink(person.link)
+                .imageNavLink(person.link)
             }
           }
         }

--- a/App/Views/Character/CharacterLargeRowView.swift
+++ b/App/Views/Character/CharacterLargeRowView.swift
@@ -12,7 +12,7 @@ struct CharacterLargeRowView: View {
         .imageStyle(width: 90, height: 90)
         .imageType(.person)
         .imageNSFW(character.nsfw)
-        .imageLink(character.link)
+        .imageNavLink(character.link)
       VStack(alignment: .leading, spacing: 4) {
         Text(character.title(with: titlePreference))
           .font(.headline)

--- a/App/Views/Character/CharacterView.swift
+++ b/App/Views/Character/CharacterView.swift
@@ -139,6 +139,7 @@ struct CharacterView: View {
       }
     }
     .handoff(url: shareLink, title: title)
+    .modifier(ZoomTransitionModifier(zoomID: ZoomNavigationID(type: .character, id: characterId)))
   }
 }
 

--- a/App/Views/Discover/CalendarSlimView.swift
+++ b/App/Views/Discover/CalendarSlimView.swift
@@ -98,7 +98,7 @@ struct CalendarWeekdaySlimView: View {
         ImageView(img: item.subject.images?.resize(.r100))
           .imageStyle(width: 60, height: 60, cornerRadius: 0)
           .imageType(.subject)
-          .imageLink(item.subject.link)
+          .imageNavLink(item.subject.link)
           .subjectPreview(item.subject)
       }
     }

--- a/App/Views/Discover/CalendarView.swift
+++ b/App/Views/Discover/CalendarView.swift
@@ -207,7 +207,7 @@ struct CalendarWeekdayView: View {
                   Spacer(minLength: 0)
                 }.padding(4)
               }
-              .imageLink(item.subject.link)
+              .imageNavLink(item.subject.link)
               .subjectPreview(item.subject)
           }
         }

--- a/App/Views/Discover/TrendingSubjectView.swift
+++ b/App/Views/Discover/TrendingSubjectView.swift
@@ -109,7 +109,7 @@ struct TrendingSubjectTypeView: View {
                   Spacer(minLength: 0)
                 }.padding(8)
               }
-              .imageLink(item.subject.link)
+              .imageNavLink(item.subject.link)
               .subjectPreview(item.subject)
           }
         }
@@ -136,7 +136,7 @@ struct TrendingSubjectTypeView: View {
                     Spacer(minLength: 0)
                   }.padding(4)
                 }
-                .imageLink(item.subject.link)
+                .imageNavLink(item.subject.link)
                 .subjectPreview(item.subject)
             }
           }

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -31,7 +31,7 @@ struct IndexRelatedItemView: View {
                 .imageStyle(width: 80, height: 100)
                 .imageType(.subject)
                 .imageNSFW(subject.nsfw)
-                .imageLink(subject.link)
+                .imageNavLink(subject.link)
               VStack(alignment: .leading) {
                 HStack {
                   Image(systemName: subject.type.icon)
@@ -76,7 +76,7 @@ struct IndexRelatedItemView: View {
               ImageView(img: character.images?.resize(.r200))
                 .imageStyle(width: 72, height: 72)
                 .imageType(.person)
-                .imageLink(character.link)
+                .imageNavLink(character.link)
               VStack(alignment: .leading) {
                 HStack {
                   Image(systemName: item.cat.icon)
@@ -122,7 +122,7 @@ struct IndexRelatedItemView: View {
               ImageView(img: person.images?.resize(.r200))
                 .imageStyle(width: 72, height: 72)
                 .imageType(.person)
-                .imageLink(person.link)
+                .imageNavLink(person.link)
               VStack(alignment: .leading) {
                 HStack {
                   Image(systemName: item.cat.icon)

--- a/App/Views/MainView.swift
+++ b/App/Views/MainView.swift
@@ -16,9 +16,11 @@ struct MainView: View {
   var body: some View {
     TabView(selection: $mainTab) {
       Tab(ChiiViewTab.timeline.title, systemImage: ChiiViewTab.timeline.icon, value: .timeline) {
-        NavigationStack(path: $timelineNav) {
-          ChiiTimelineView()
-            .navigationDestination(for: NavDestination.self) { $0 }
+        ZoomTransitionContainer {
+          NavigationStack(path: $timelineNav) {
+            ChiiTimelineView()
+              .navigationDestination(for: NavDestination.self) { $0 }
+          }
         }
         .environment(
           \.openURL,
@@ -34,9 +36,11 @@ struct MainView: View {
 
       if isAuthenticated {
         Tab(ChiiViewTab.progress.title, systemImage: ChiiViewTab.progress.icon, value: .progress) {
-          NavigationStack(path: $progressNav) {
-            ChiiProgressView()
-              .navigationDestination(for: NavDestination.self) { $0 }
+          ZoomTransitionContainer {
+            NavigationStack(path: $progressNav) {
+              ChiiProgressView()
+                .navigationDestination(for: NavDestination.self) { $0 }
+            }
           }
           .environment(
             \.openURL,
@@ -53,9 +57,11 @@ struct MainView: View {
 
       if !isolationMode {
         Tab(ChiiViewTab.rakuen.title, systemImage: ChiiViewTab.rakuen.icon, value: .rakuen) {
-          NavigationStack(path: $rakuenNav) {
-            ChiiRakuenView()
-              .navigationDestination(for: NavDestination.self) { $0 }
+          ZoomTransitionContainer {
+            NavigationStack(path: $rakuenNav) {
+              ChiiRakuenView()
+                .navigationDestination(for: NavDestination.self) { $0 }
+            }
           }
           .environment(
             \.openURL,
@@ -80,9 +86,11 @@ struct MainView: View {
         ChiiViewTab.discover.title, systemImage: ChiiViewTab.discover.icon,
         value: ChiiViewTab.discover, role: .search
       ) {
-        NavigationStack(path: $discoverNav) {
-          ChiiDiscoverView()
-            .navigationDestination(for: NavDestination.self) { $0 }
+        ZoomTransitionContainer {
+          NavigationStack(path: $discoverNav) {
+            ChiiDiscoverView()
+              .navigationDestination(for: NavDestination.self) { $0 }
+          }
         }
         .environment(
           \.openURL,

--- a/App/Views/Person/PersonCastItemView.swift
+++ b/App/Views/Person/PersonCastItemView.swift
@@ -11,7 +11,7 @@ struct PersonCastItemView: View {
         ImageView(img: item.character.images?.medium)
           .imageStyle(width: 60, height: 60, alignment: .top)
           .imageType(.person)
-          .imageLink(item.character.link)
+          .imageNavLink(item.character.link)
 
         VStack(alignment: .leading) {
           Text(item.character.title(with: titlePreference).withLink(item.character.link))
@@ -55,7 +55,7 @@ struct PersonCastItemView: View {
               ImageView(img: relation.subject.images?.small)
                 .imageStyle(width: 40, height: 40, alignment: .top)
                 .imageType(.subject)
-                .imageLink(relation.subject.link)
+                .imageNavLink(relation.subject.link)
             }.frame(minHeight: 40)
           }
         }

--- a/App/Views/Person/PersonLargeRowView.swift
+++ b/App/Views/Person/PersonLargeRowView.swift
@@ -12,7 +12,7 @@ struct PersonLargeRowView: View {
         .imageStyle(width: 90, height: 90)
         .imageType(.person)
         .imageNSFW(person.nsfw)
-        .imageLink(person.link)
+        .imageNavLink(person.link)
       VStack(alignment: .leading, spacing: 4) {
         Text(person.title(with: titlePreference))
           .font(.headline)

--- a/App/Views/Person/PersonView.swift
+++ b/App/Views/Person/PersonView.swift
@@ -139,6 +139,7 @@ struct PersonView: View {
       }
     }
     .handoff(url: shareLink, title: title)
+    .modifier(ZoomTransitionModifier(zoomID: ZoomNavigationID(type: .person, id: personId)))
   }
 }
 

--- a/App/Views/Person/PersonWorksItemView.swift
+++ b/App/Views/Person/PersonWorksItemView.swift
@@ -12,7 +12,7 @@ struct PersonWorksItemView: View {
         ImageView(img: item.subject.images?.resize(.r200))
           .imageStyle(width: 60, height: 60)
           .imageType(.subject)
-          .imageLink(item.subject.link)
+          .imageNavLink(item.subject.link)
         VStack(alignment: .leading) {
           VStack(alignment: .leading) {
             Text(item.subject.title(with: titlePreference).withLink(item.subject.link))

--- a/App/Views/Profile/CollectionRowView.swift
+++ b/App/Views/Profile/CollectionRowView.swift
@@ -13,7 +13,7 @@ struct CollectionRowView: View {
       ImageView(img: subject.images?.resize(.r200))
         .imageStyle(width: 60, height: 60)
         .imageType(.subject)
-        .imageLink(subject.link)
+        .imageNavLink(subject.link)
       VStack(alignment: .leading) {
         Text(subject.title(with: titlePreference).withLink(subject.link))
           .lineLimit(1)

--- a/App/Views/Profile/CollectionSubjectTypeView.swift
+++ b/App/Views/Profile/CollectionSubjectTypeView.swift
@@ -85,7 +85,7 @@ struct CollectionSubjectTypeView: View {
           ImageView(img: subject.images?.resize(.r200))
             .imageStyle(width: 80, height: 80)
             .imageType(.subject)
-            .imageLink(subject.link)
+            .imageNavLink(subject.link)
         }
       }
     }.animation(.default, value: subjects)

--- a/App/Views/Progress/ProgressListView.swift
+++ b/App/Views/Progress/ProgressListView.swift
@@ -76,7 +76,7 @@ struct ProgressListItemView: View {
           .imageBadge(show: subject.interest?.private ?? false) {
             Image(systemName: "lock")
           }
-          .imageLink(subject.link)
+          .imageNavLink(subject.link)
         VStack(alignment: .leading, spacing: 4) {
           NavigationLink(value: NavDestination.subject(subjectId)) {
             VStack(alignment: .leading, spacing: 4) {

--- a/App/Views/Progress/ProgressTileView.swift
+++ b/App/Views/Progress/ProgressTileView.swift
@@ -101,7 +101,7 @@ struct ProgressTileItemView: View {
         .imageBadge(show: subject.interest?.private ?? false) {
           Image(systemName: "lock")
         }
-        .imageLink(subject.link)
+        .imageNavLink(subject.link)
 
       VStack(alignment: .leading, spacing: 4) {
         VStack(alignment: .leading, spacing: 4) {

--- a/App/Views/Subject/SubjectCharacterListView.swift
+++ b/App/Views/Subject/SubjectCharacterListView.swift
@@ -43,7 +43,7 @@ struct SubjectCharacterListView: View {
               .imageCaption {
                 Text(item.type.description)
               }
-              .imageLink(item.character.link)
+              .imageNavLink(item.character.link)
             VStack(alignment: .leading) {
               VStack(alignment: .leading) {
                 HStack {
@@ -70,7 +70,7 @@ struct SubjectCharacterListView: View {
                     ImageView(img: person.images?.grid)
                       .imageStyle(width: 40, height: 40, alignment: .top)
                       .imageType(.person)
-                      .imageLink(person.link)
+                      .imageNavLink(person.link)
                     VStack(alignment: .leading) {
                       Text(person.title(with: titlePreference).withLink(person.link))
                         .foregroundStyle(.linkText)

--- a/App/Views/Subject/SubjectCharactersView.swift
+++ b/App/Views/Subject/SubjectCharactersView.swift
@@ -58,7 +58,7 @@ struct CharacterCard: View {
       ImageView(img: item.character.images?.medium)
         .imageStyle(width: 72, height: 108, alignment: .top)
         .imageType(.person)
-        .imageLink(item.character.link)
+        .imageNavLink(item.character.link)
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(radius: 2)
 

--- a/App/Views/Subject/SubjectLargeRowView.swift
+++ b/App/Views/Subject/SubjectLargeRowView.swift
@@ -15,7 +15,7 @@ struct SubjectLargeRowView: View {
         .imageStyle(width: 90, height: subject.typeEnum.coverHeight(for: 90))
         .imageType(.subject)
         .imageNSFW(subject.nsfw)
-        .imageLink(subject.link)
+        .imageNavLink(subject.link)
       VStack(alignment: .leading) {
         // title
         HStack {

--- a/App/Views/Subject/SubjectOffprintsView.swift
+++ b/App/Views/Subject/SubjectOffprintsView.swift
@@ -43,7 +43,7 @@ struct SubjectOffprintsView: View {
               Label(ctype.description(offprint.subject.type), systemImage: ctype.icon)
                 .labelStyle(.compact)
             }
-            .imageLink(offprint.subject.link)
+            .imageNavLink(offprint.subject.link)
             .padding(2)
             .shadow(radius: 2)
         }

--- a/App/Views/Subject/SubjectRecsView.swift
+++ b/App/Views/Subject/SubjectRecsView.swift
@@ -58,7 +58,7 @@ struct SubjectRecsView: View {
                 Label(ctype.description(rec.subject.type), systemImage: ctype.icon)
                   .labelStyle(.compact)
               }
-              .imageLink(rec.subject.link)
+              .imageNavLink(rec.subject.link)
               .padding(2)
               .shadow(radius: 2)
             Text(rec.subject.title(with: titlePreference))

--- a/App/Views/Subject/SubjectRelationListView.swift
+++ b/App/Views/Subject/SubjectRelationListView.swift
@@ -38,7 +38,7 @@ struct SubjectRelationListView: View {
             ImageView(img: item.subject.images?.resize(.r200))
               .imageStyle(width: 60, height: 60)
               .imageType(.subject)
-              .imageLink(item.subject.link)
+              .imageNavLink(item.subject.link)
             VStack(alignment: .leading) {
               HStack {
                 VStack(alignment: .leading) {

--- a/App/Views/Subject/SubjectRelationsView.swift
+++ b/App/Views/Subject/SubjectRelationsView.swift
@@ -74,7 +74,7 @@ struct SubjectRelationsView: View {
                 Label(ctype.description(relation.subject.type), systemImage: ctype.icon)
                   .labelStyle(.compact)
               }
-              .imageLink(relation.subject.link)
+              .imageNavLink(relation.subject.link)
               .padding(2)
               .shadow(radius: 2)
             Text(relation.subject.title(with: titlePreference))

--- a/App/Views/Subject/SubjectStaffListView.swift
+++ b/App/Views/Subject/SubjectStaffListView.swift
@@ -24,7 +24,7 @@ struct SubjectStaffListView: View {
             ImageView(img: item.staff.images?.medium)
               .imageStyle(width: 60, height: 60, alignment: .top)
               .imageType(.person)
-              .imageLink(item.staff.link)
+              .imageNavLink(item.staff.link)
             VStack(alignment: .leading) {
               Text(item.staff.name.withLink(item.staff.link))
                 .font(.callout)

--- a/App/Views/Subject/SubjectTopicDetailView.swift
+++ b/App/Views/Subject/SubjectTopicDetailView.swift
@@ -118,7 +118,7 @@ struct SubjectTopicDetailView: View {
                 ImageView(img: topic.subject.images?.small)
                   .imageStyle(width: 20, height: 20)
                   .imageType(.subject)
-                  .imageLink(topic.subject.link)
+                  .imageNavLink(topic.subject.link)
                 Text(topic.subject.title(with: titlePreference).withLink(topic.subject.link))
                   .font(.subheadline)
                 Spacer()

--- a/App/Views/Subject/SubjectView.swift
+++ b/App/Views/Subject/SubjectView.swift
@@ -166,6 +166,7 @@ struct SubjectDetailView: View {
       }
     }
     .handoff(url: shareLink, title: subject.name)
+    .modifier(ZoomTransitionModifier(zoomID: ZoomNavigationID(type: .subject, id: subject.subjectId)))
   }
 }
 

--- a/App/Views/Timeline/TimelineItemView.swift
+++ b/App/Views/Timeline/TimelineItemView.swift
@@ -112,7 +112,7 @@ struct TimelineItemView: View {
                     .imageStyle(width: 60, height: 72)
                     .imageType(.subject)
                     .imageNSFW(subject.nsfw)
-                    .imageLink(subject.link)
+                    .imageNavLink(subject.link)
                     .subjectPreview(subject)
                 }
               }
@@ -175,13 +175,13 @@ struct TimelineItemView: View {
                   ImageView(img: character.images?.grid)
                     .imageStyle(width: 60, height: 60)
                     .imageType(.person)
-                    .imageLink(character.link)
+                    .imageNavLink(character.link)
                 }
                 ForEach(mono.persons.prefix(5)) { person in
                   ImageView(img: person.images?.grid)
                     .imageStyle(width: 60, height: 60)
                     .imageType(.person)
-                    .imageLink(person.link)
+                    .imageNavLink(person.link)
                 }
               }
             }

--- a/App/Views/User/UserCharacterCollectionView.swift
+++ b/App/Views/User/UserCharacterCollectionView.swift
@@ -55,7 +55,7 @@ struct UserCharacterCollectionView: View {
                 ImageView(img: character.images?.resize(.r200))
                   .imageStyle(width: 60, height: 60)
                   .imageType(.person)
-                  .imageLink(character.link)
+                  .imageNavLink(character.link)
                   .shadow(radius: 2)
                 Text(character.title(with: titlePreference))
                   .font(.caption2)

--- a/App/Views/User/UserPersonCollectionView.swift
+++ b/App/Views/User/UserPersonCollectionView.swift
@@ -55,7 +55,7 @@ struct UserPersonCollectionView: View {
                 ImageView(img: person.images?.resize(.r200))
                   .imageStyle(width: 60, height: 60)
                   .imageType(.person)
-                  .imageLink(person.link)
+                  .imageNavLink(person.link)
                   .shadow(radius: 2)
                 Text(person.title(with: titlePreference))
                   .font(.caption2)

--- a/App/Views/User/UserSubjectCollectionRowView.swift
+++ b/App/Views/User/UserSubjectCollectionRowView.swift
@@ -11,7 +11,7 @@ struct UserSubjectCollectionRowView: View {
       ImageView(img: subject.images?.resize(.r200))
         .imageStyle(width: 60, height: subject.type.coverHeight(for: 60))
         .imageType(.subject)
-        .imageLink(subject.link)
+        .imageNavLink(subject.link)
       VStack(alignment: .leading) {
         Text(subject.title(with: titlePreference).withLink(subject.link))
           .lineLimit(1)

--- a/App/Views/User/UserSubjectCollectionView.swift
+++ b/App/Views/User/UserSubjectCollectionView.swift
@@ -100,7 +100,7 @@ struct UserSubjectCollectionView: View {
                   ImageView(img: subject.images?.resize(.r200))
                     .imageStyle(width: 60, height: imageHeight)
                     .imageType(.subject)
-                    .imageLink(subject.link)
+                    .imageNavLink(subject.link)
                     .subjectPreview(subject)
                     .shadow(radius: 2)
                   Text(subject.title(with: titlePreference))


### PR DESCRIPTION
- Add ImageNavConfig.swift with imageNavLink() modifier and ZoomTransitionModifier
- Use ZoomTransitionContainer to provide shared namespace via Environment
- Apply zoom transition to SubjectView, CharacterView, PersonView destinations
- Update 30+ source views to use imageNavLink() for subject/character/person images
- Fallback to Link behavior on iOS < 18