### PR TITLE
fix: persist collection updates immediately

### DIFF
--- a/App/Database/Operator.swift
+++ b/App/Database/Operator.swift
@@ -368,7 +368,7 @@ extension DatabaseOperator {
       break
     }
 
-    self.commit()
+    try self.commitImmediately()
   }
 
   public func updateSubjectCollection(
@@ -432,7 +432,7 @@ extension DatabaseOperator {
     }
     subject.interest?.updatedAt = now - 1
     subject.collectedAt = now - 1
-    self.commit()
+    try self.commitImmediately()
   }
 
   public func updateEpisodeCollection(
@@ -468,7 +468,7 @@ extension DatabaseOperator {
     }
     episode.subject?.interest?.updatedAt = now - 1
     episode.subject?.collectedAt = now - 1
-    self.commit()
+    try self.commitImmediately()
   }
 
   public func updateCharacterCollection(characterId: Int, collectedAt: Int) throws {
@@ -481,7 +481,7 @@ extension DatabaseOperator {
       return
     }
     character.collectedAt = collectedAt
-    self.commit()
+    try self.commitImmediately()
   }
 
   public func updatePersonCollection(personId: Int, collectedAt: Int) throws {
@@ -494,7 +494,7 @@ extension DatabaseOperator {
       return
     }
     person.collectedAt = collectedAt
-    self.commit()
+    try self.commitImmediately()
   }
 }
 
@@ -1073,7 +1073,7 @@ extension DatabaseOperator {
     let group = try self.getGroup(name)
     if let group = group {
       group.joinedAt = joinedAt
-      self.commit()
+      try self.commitImmediately()
     }
   }
 }


### PR DESCRIPTION
## Problem
Book progress updates and other explicit collection actions could briefly show stale values after a successful request because the local SwiftData write was still deferred.

## Approach
Use immediate saves for user-triggered collection mutations so the current view observes the updated state as soon as the request succeeds, instead of waiting for the delayed commit window to close.

## Scope
- Persist book chapter and volume progress immediately
- Persist subject collection, episode collection, character and person collection changes immediately
- Persist group join state immediately

## Validation
- [x] `make build-ci`
