### PR TITLE
fix: stabilize bbcode inline attachment layout

### DIFF
--- a/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
+++ b/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
@@ -26,6 +26,16 @@ extension NSAttributedString.Key {
   static let bbcodeMask = NSAttributedString.Key("tv.bgm.bbcode.mask")
 }
 
+enum BBCodeLayoutMetrics {
+  static let lineHeightMultiple: CGFloat = 1.08
+  static let textContainerVerticalInset: CGFloat = 2
+
+  static func inlineAttachmentVerticalOffset(for height: CGFloat, font: UIFont) -> CGFloat {
+    let overflow = max(0, height - font.lineHeight)
+    return font.descender - overflow / 2
+  }
+}
+
 extension BBCode {
   @MainActor
   func preparedDocument(_ bbcode: String, textSize: Int) -> BBCodePreparedDocument {
@@ -69,12 +79,16 @@ private struct BBCodeTextKitRenderer {
   let baseFont: UIFont
   let linkColor: UIColor
   let secondaryColor: UIColor
+  let baseParagraphStyle: NSParagraphStyle
 
   init(textSize: Int) {
     self.textSize = CGFloat(textSize)
     self.baseFont = .systemFont(ofSize: CGFloat(textSize))
     self.linkColor = UIColor(named: "LinkTextColor") ?? .systemBlue
     self.secondaryColor = .secondaryLabel
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.lineHeightMultiple = BBCodeLayoutMetrics.lineHeightMultiple
+    self.baseParagraphStyle = paragraphStyle.copy() as? NSParagraphStyle ?? paragraphStyle
   }
 
   func renderBlocks(root: Node) -> [BBCodePreparedBlock] {
@@ -383,6 +397,7 @@ private struct BBCodeTextKitRenderer {
     [
       .font: baseFont,
       .foregroundColor: UIColor.label,
+      .paragraphStyle: baseParagraphStyle,
     ]
   }
 
@@ -697,7 +712,7 @@ private struct BBCodeTextKitRenderer {
       placeholderImage: baseImage,
       displaySize: displaySize
     )
-    return NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+    return makeInlineAttachmentText(attachment)
   }
 
   private func renderBmo(_ node: Node) -> NSMutableAttributedString {
@@ -708,11 +723,8 @@ private struct BBCodeTextKitRenderer {
       return makeText("(\(node.attr))")
     }
 
-    let attachment = NSTextAttachment()
-    attachment.image = UIImage(cgImage: cgImage)
-    attachment.bounds = inlineAttachmentBounds(
-      for: CGSize(width: textSize + 4, height: textSize + 4))
-    return NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+    let attachment = InlineImageTextAttachment(image: UIImage(cgImage: cgImage), size: CGSize(width: textSize + 4, height: textSize + 4))
+    return makeInlineAttachmentText(attachment)
   }
 
   private func collectListItemNodes(from children: [Node]) -> [[Node]] {
@@ -762,8 +774,16 @@ private struct BBCodeTextKitRenderer {
     )
   }
 
-  private func inlineAttachmentBounds(for size: CGSize) -> CGRect {
-    CGRect(x: 0, y: baseFont.descender, width: size.width, height: size.height)
+  private func makeInlineAttachmentText(_ attachment: NSTextAttachment) -> NSMutableAttributedString {
+    let attributed = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+    attributed.addAttributes(
+      [
+        .font: baseFont,
+        .paragraphStyle: baseParagraphStyle,
+      ],
+      range: attributed.fullRange
+    )
+    return attributed
   }
 
   private func makeText(
@@ -776,6 +796,7 @@ private struct BBCodeTextKitRenderer {
       attributes: [
         .font: font ?? baseFont,
         .foregroundColor: color,
+        .paragraphStyle: baseParagraphStyle,
       ]
     )
   }
@@ -975,7 +996,7 @@ final class SmileyTextAttachment: NSTextAttachment {
     let font = (attributes[.font] as? UIFont) ?? .systemFont(ofSize: 16)
     return CGRect(
       x: 0,
-      y: font.descender,
+      y: BBCodeLayoutMetrics.inlineAttachmentVerticalOffset(for: renderedSize.height, font: font),
       width: renderedSize.width,
       height: renderedSize.height
     )
@@ -1002,5 +1023,38 @@ final class SmileyTextAttachment: NSTextAttachment {
     format.opaque = false
     let renderer = UIGraphicsImageRenderer(size: renderedSize, format: format)
     return renderer.image { _ in }
+  }
+}
+
+final class InlineImageTextAttachment: NSTextAttachment {
+  let renderedSize: CGSize
+
+  init(image: UIImage, size: CGSize) {
+    self.renderedSize = size
+    super.init(data: nil, ofType: nil)
+    self.image = image
+    self.bounds = CGRect(origin: .zero, size: size)
+    allowsTextAttachmentView = false
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func attachmentBounds(
+    for attributes: [NSAttributedString.Key: Any],
+    location: any NSTextLocation,
+    textContainer: NSTextContainer?,
+    proposedLineFragment: CGRect,
+    position: CGPoint
+  ) -> CGRect {
+    let font = (attributes[.font] as? UIFont) ?? .systemFont(ofSize: 16)
+    return CGRect(
+      x: 0,
+      y: BBCodeLayoutMetrics.inlineAttachmentVerticalOffset(for: renderedSize.height, font: font),
+      width: renderedSize.width,
+      height: renderedSize.height
+    )
   }
 }

--- a/BBCode/Sources/BBCode/Views/BBCodeUIKitView.swift
+++ b/BBCode/Sources/BBCode/Views/BBCodeUIKitView.swift
@@ -151,7 +151,12 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
     isSelectable = true
     isScrollEnabled = false
     textDragInteraction?.isEnabled = false
-    textContainerInset = .zero
+    textContainerInset = UIEdgeInsets(
+      top: BBCodeLayoutMetrics.textContainerVerticalInset,
+      left: 0,
+      bottom: BBCodeLayoutMetrics.textContainerVerticalInset,
+      right: 0
+    )
     textContainer.lineFragmentPadding = 0
     delegate = self
     linkTextAttributes = [:]

--- a/BBCode/Tests/BBCodeTests/PreparedDocumentTests.swift
+++ b/BBCode/Tests/BBCodeTests/PreparedDocumentTests.swift
@@ -99,6 +99,60 @@ final class PreparedDocumentTests: XCTestCase {
     )
   }
 
+  func testSmileyAttachmentCarriesFontAndParagraphStyle() {
+    let document = BBCode().preparedDocument("(bgm38)", textSize: 18)
+
+    XCTAssertEqual(document.blocks.count, 1)
+
+    guard let attributedText = textBlock(for: document.blocks[0]) else {
+      return XCTFail("Expected text block")
+    }
+
+    let attachmentRange = attachmentRange(in: attributedText)
+    guard let attachmentRange else {
+      return XCTFail("Expected attachment range")
+    }
+
+    guard
+      let font = attributedText.attribute(.font, at: attachmentRange.location, effectiveRange: nil)
+        as? UIFont
+    else {
+      return XCTFail("Expected font")
+    }
+    XCTAssertEqual(font.pointSize, 18, accuracy: 0.01)
+
+    guard
+      let paragraphStyle = attributedText.attribute(
+        .paragraphStyle,
+        at: attachmentRange.location,
+        effectiveRange: nil
+      ) as? NSParagraphStyle
+    else {
+      return XCTFail("Expected paragraph style")
+    }
+    XCTAssertEqual(
+      paragraphStyle.lineHeightMultiple,
+      BBCodeLayoutMetrics.lineHeightMultiple,
+      accuracy: 0.001
+    )
+
+    guard let attachment = attributedText.attribute(
+      .attachment,
+      at: attachmentRange.location,
+      effectiveRange: nil
+    ) as? SmileyTextAttachment else {
+      return XCTFail("Expected smiley attachment")
+    }
+
+    let offset = BBCodeLayoutMetrics.inlineAttachmentVerticalOffset(
+      for: attachment.renderedSize.height,
+      font: font
+    )
+
+    XCTAssertLessThan(offset, 0)
+    XCTAssertGreaterThan(offset, font.descender)
+  }
+
   private func textBlock(for block: BBCodePreparedBlock) -> NSAttributedString? {
     guard case .text(let attributedText) = block.payload else {
       return nil


### PR DESCRIPTION
## Problem
BBCode inline smileys and BMO attachments could distort multi-line text layout. When a later line contained a taller inline attachment, earlier lines could be pushed upward and the first line could clip against the top edge of the text view.

## Approach
Adjust inline attachment vertical alignment using font metrics instead of a fixed descender offset, and give BBCode text blocks a small vertical text container inset so the first line keeps enough breathing room. Add shared layout metrics so inline attachments and plain text use the same paragraph baseline assumptions.

## Scope
- Update BBCode inline attachment positioning for smileys and BMO emoji
- Apply a small default paragraph line-height multiplier for BBCode text blocks
- Add regression coverage for attachment font and paragraph style propagation

## Validation
- [x] `xcodebuild -scheme BBCode -project Bangumi.xcodeproj -destination 'generic/platform=iOS Simulator' build`
- [ ] `xcodebuild test -scheme BBCode ...` (the current `BBCode` scheme is not configured for the test action)
