### PR TITLE
fix: optimize topic BBCode rendering

### DIFF
--- a/App/Views/Group/GroupTopicDetailView.swift
+++ b/App/Views/Group/GroupTopicDetailView.swift
@@ -110,6 +110,7 @@ struct GroupTopicDetailView: View {
   var body: some View {
     ScrollView {
       if let topic = topic {
+        let replies = filteredReplies
         LazyVStack(alignment: .leading, spacing: 8, pinnedViews: [.sectionHeaders]) {
           CardView {
             VStack(alignment: .leading, spacing: 8) {
@@ -157,14 +158,14 @@ struct GroupTopicDetailView: View {
           // Replies section with sticky slider header
           Section {
             // Filtered and sorted replies
-            if !filteredReplies.isEmpty {
-              ForEach(Array(filteredReplies.enumerated()), id: \.element) { displayIdx, reply in
+            if !replies.isEmpty {
+              ForEach(Array(replies.enumerated()), id: \.element.id) { displayIdx, reply in
                 let originalIdx =
                   topic.replies.firstIndex(where: { $0.id == reply.id }) ?? displayIdx
                 ReplyItemView(
                   type: .group(topic.group.name), topicId: topicId, idx: originalIdx,
                   reply: reply, author: topic.creator)
-                if reply.id != filteredReplies.last?.id {
+                if reply.id != replies.last?.id {
                   Divider()
                 }
               }
@@ -213,7 +214,6 @@ struct GroupTopicDetailView: View {
         }
         .animation(.default, value: filterMode)
         .animation(.default, value: sortOrder)
-        .animation(.default, value: replyLimit)
         .padding(8)
         .refreshable {
           Task {

--- a/App/Views/Subject/SubjectTopicDetailView.swift
+++ b/App/Views/Subject/SubjectTopicDetailView.swift
@@ -111,6 +111,7 @@ struct SubjectTopicDetailView: View {
   var body: some View {
     ScrollView {
       if let topic = topic {
+        let replies = filteredReplies
         LazyVStack(alignment: .leading, spacing: 8, pinnedViews: [.sectionHeaders]) {
           CardView {
             VStack(alignment: .leading, spacing: 8) {
@@ -159,14 +160,14 @@ struct SubjectTopicDetailView: View {
           // Replies section with sticky slider header
           Section {
             // Filtered and sorted replies
-            if !filteredReplies.isEmpty {
-              ForEach(Array(filteredReplies.enumerated()), id: \.element) { displayIdx, reply in
+            if !replies.isEmpty {
+              ForEach(Array(replies.enumerated()), id: \.element.id) { displayIdx, reply in
                 let originalIdx =
                   topic.replies.firstIndex(where: { $0.id == reply.id }) ?? displayIdx
                 ReplyItemView(
                   type: .subject(topic.subject.id), topicId: topicId, idx: originalIdx,
                   reply: reply, author: topic.creator)
-                if reply.id != filteredReplies.last?.id {
+                if reply.id != replies.last?.id {
                   Divider()
                 }
               }
@@ -215,7 +216,6 @@ struct SubjectTopicDetailView: View {
         }
         .animation(.default, value: filterMode)
         .animation(.default, value: sortOrder)
-        .animation(.default, value: replyLimit)
         .padding(8)
         .refreshable {
           Task {

--- a/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
+++ b/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
@@ -5,6 +5,49 @@ struct BBCodePreparedDocument {
   let blocks: [BBCodePreparedBlock]
 }
 
+@MainActor
+private final class BBCodePreparedDocumentCache {
+  static let shared = BBCodePreparedDocumentCache()
+
+  private struct Key: Hashable {
+    let bbcode: String
+    let textSize: Int
+  }
+
+  private let limit = 256
+  private var documents: [Key: BBCodePreparedDocument] = [:]
+  private var accessOrder: [Key] = []
+
+  func document(for bbcode: String, textSize: Int) -> BBCodePreparedDocument? {
+    let key = Key(bbcode: bbcode, textSize: textSize)
+    guard let document = documents[key] else {
+      return nil
+    }
+
+    markRecentlyUsed(key)
+    return document
+  }
+
+  func store(_ document: BBCodePreparedDocument, for bbcode: String, textSize: Int) {
+    let key = Key(bbcode: bbcode, textSize: textSize)
+    documents[key] = document
+    markRecentlyUsed(key)
+    trimIfNeeded()
+  }
+
+  private func markRecentlyUsed(_ key: Key) {
+    accessOrder.removeAll { $0 == key }
+    accessOrder.append(key)
+  }
+
+  private func trimIfNeeded() {
+    while accessOrder.count > limit, let oldestKey = accessOrder.first {
+      accessOrder.removeFirst()
+      documents.removeValue(forKey: oldestKey)
+    }
+  }
+}
+
 struct BBCodePreparedListItem: Identifiable {
   let id: Int
   let blocks: [BBCodePreparedBlock]
@@ -38,21 +81,32 @@ enum BBCodeLayoutMetrics {
 
 extension BBCode {
   @MainActor
-  func preparedDocument(_ bbcode: String, textSize: Int) -> BBCodePreparedDocument {
+  func preparedDocument(_ bbcode: String, textSize: Int) async -> BBCodePreparedDocument {
+    if let cachedDocument = BBCodePreparedDocumentCache.shared.document(
+      for: bbcode,
+      textSize: textSize
+    ) {
+      return cachedDocument
+    }
+
     let worker = Worker(tagManager: tagManager)
 
     guard let tree = worker.parse(bbcode) else {
       let renderer = BBCodeTextKitRenderer(textSize: textSize)
-      return BBCodePreparedDocument(
+      let document = BBCodePreparedDocument(
         blocks: [
           BBCodePreparedBlock(id: 0, payload: .text(renderer.makePlainText(bbcode)))
         ]
       )
+      BBCodePreparedDocumentCache.shared.store(document, for: bbcode, textSize: textSize)
+      return document
     }
 
     handleNewlineAndParagraph(node: tree, tagManager: tagManager)
     let renderer = BBCodeTextKitRenderer(textSize: textSize)
-    return BBCodePreparedDocument(blocks: renderer.renderBlocks(root: tree))
+    let document = BBCodePreparedDocument(blocks: renderer.renderBlocks(root: tree))
+    BBCodePreparedDocumentCache.shared.store(document, for: bbcode, textSize: textSize)
+    return document
   }
 }
 

--- a/BBCode/Sources/BBCode/Views/BBCodeView.swift
+++ b/BBCode/Sources/BBCode/Views/BBCodeView.swift
@@ -28,7 +28,7 @@ public struct BBCodeView: View {
       }
     }
     .task(id: "\(textSize)|\(code)") {
-      document = BBCode().preparedDocument(code, textSize: textSize)
+      document = await BBCode().preparedDocument(code, textSize: textSize)
     }
   }
 }


### PR DESCRIPTION
## Problem
Topic detail pages can feel sluggish when they contain many BBCode-heavy replies because each row may repeat parse/render work and dynamic reply filtering can trigger broad layout updates.

## Approach
Cache prepared BBCode documents behind the existing TextKit renderer so identical content can be reused across view updates without switching each reply to a heavier WKWebView. The cache stays on the main actor because the prepared document contains UIKit and attributed string objects.

## Scope
- Add a bounded prepared BBCode document cache
- Load `BBCodeView` content through the cached async path
- Reuse filtered replies within topic detail body evaluation
- Use stable reply IDs and avoid slider-driven implicit list animation

## Validation
- [x] `make format`
- [x] `make build-ci`
