### PR TITLE
fix: keep topic action status inline

### DIFF
--- a/App/Components/PostTopicActionStateView.swift
+++ b/App/Components/PostTopicActionStateView.swift
@@ -43,6 +43,8 @@ struct PostTopicActionStateView: View {
         Text(actionName)
           .font(.footnote.bold())
           .foregroundStyle(.white)
+          .lineLimit(1)
+          .fixedSize(horizontal: true, vertical: false)
           .padding(.horizontal, 10)
           .padding(.vertical, 5)
           .background(state.color)
@@ -81,17 +83,23 @@ struct PostTopicActionStateView: View {
             Text(anonymizedHash).lineLimit(1)
           }
         } else if let creator = creator {
-          Text(creator.nickname.withLink(creator.link)).lineLimit(1)
+          Text(creator.nickname.withLink(creator.link))
+            .lineLimit(1)
+            .truncationMode(.tail)
         } else {
           Text("用户 \(creatorID)")
             .lineLimit(1)
+            .truncationMode(.tail)
         }
         if let actionDescription = state.actionDescription {
           Text(actionDescription)
             .font(.footnote)
             .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
         }
       }
+      .layoutPriority(1)
 
       Spacer()
 
@@ -99,6 +107,7 @@ struct PostTopicActionStateView: View {
         .lineLimit(1)
         .font(.caption)
         .foregroundStyle(.secondary)
+        .fixedSize(horizontal: true, vertical: false)
     }
   }
 }


### PR DESCRIPTION
## Problem
Topic detail rows can squeeze short action status text such as "删除了回复" into two lines when the row is narrow or the user name takes too much horizontal space. That makes compact deleted-reply rows look uneven and harder to scan.

## Approach
Keep the action badge, action description, and timestamp at their intrinsic single-line widths, and make the user identity area the part that yields by truncating long names. This preserves the important status signal without changing the shared data model or topic row structure.

## Scope
- Update `PostTopicActionStateView` layout priorities and single-line constraints
- Preserve the shared component behavior for topic replies, subreplies, and comment states

## Validation
- [x] `make format`
- [x] `make build-ci`
