### PR TITLE
fix: improve bbcode image layout

### DIFF
--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -14,7 +14,6 @@ public struct ImagePreviewer: View {
   @State private var reloadID = UUID()
   @State private var shouldRefresh = false
   @State private var loadedImage: UIImage?
-  @State private var shareItem: ImagePreviewShareItem?
 
   @Environment(\.dismiss) private var dismiss
 
@@ -84,7 +83,7 @@ public struct ImagePreviewer: View {
             Spacer()
 
             Button {
-              shareItem = ImagePreviewShareItem(item: loadedImage ?? url)
+              presentShareSheet()
             } label: {
               controlLabel(systemName: "square.and.arrow.up")
             }
@@ -105,9 +104,6 @@ public struct ImagePreviewer: View {
       .ignoresSafeArea()
     }
     .navigationTransitionZoomIfAvailable(sourceID: zoomID, in: zoomNamespace)
-    .sheet(item: $shareItem) { shareItem in
-      ImagePreviewShareSheet(items: [shareItem.item])
-    }
   }
 
   private var imageOptions: SDWebImageOptions {
@@ -124,27 +120,31 @@ public struct ImagePreviewer: View {
     reloadID = UUID()
   }
 
+  private func presentShareSheet() {
+    guard let presenter = UIViewController.activeTopMostPresentedViewController else {
+      return
+    }
+
+    let controller = UIActivityViewController(
+      activityItems: [loadedImage ?? url],
+      applicationActivities: nil
+    )
+    controller.popoverPresentationController?.sourceView = presenter.view
+    controller.popoverPresentationController?.sourceRect = CGRect(
+      x: presenter.view.bounds.maxX - 44,
+      y: presenter.view.safeAreaInsets.top + 44,
+      width: 1,
+      height: 1
+    )
+    presenter.present(controller, animated: true)
+  }
+
   @ViewBuilder
   private func controlLabel(systemName: String) -> some View {
     Image(systemName: systemName)
       .foregroundColor(.white)
       .contentShape(Circle())
   }
-}
-
-private struct ImagePreviewShareItem: Identifiable {
-  let id = UUID()
-  let item: Any
-}
-
-private struct ImagePreviewShareSheet: UIViewControllerRepresentable {
-  let items: [Any]
-
-  func makeUIViewController(context: Context) -> UIActivityViewController {
-    UIActivityViewController(activityItems: items, applicationActivities: nil)
-  }
-
-  func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
 private struct ZoomableImageScrollView: UIViewRepresentable {
@@ -322,5 +322,19 @@ private final class ZoomableImageScrollCoordinator: NSObject, UIScrollViewDelega
     let originX = center.x - (width / 2)
     let originY = center.y - (height / 2)
     return CGRect(x: originX, y: originY, width: width, height: height)
+  }
+}
+
+extension UIViewController {
+  fileprivate static var activeTopMostPresentedViewController: UIViewController? {
+    let activeScene = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first { $0.activationState == .foregroundActive }
+    let rootViewController = activeScene?.windows.first { $0.isKeyWindow }?.rootViewController
+    return rootViewController?.topMostPresentedViewController
+  }
+
+  fileprivate var topMostPresentedViewController: UIViewController {
+    presentedViewController?.topMostPresentedViewController ?? self
   }
 }

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -13,6 +13,8 @@ public struct ImagePreviewer: View {
   @State private var showControls = true
   @State private var reloadID = UUID()
   @State private var shouldRefresh = false
+  @State private var loadedImage: UIImage?
+  @State private var shareItem: ImagePreviewShareItem?
 
   @Environment(\.dismiss) private var dismiss
 
@@ -41,10 +43,11 @@ public struct ImagePreviewer: View {
               shouldRefresh = false
             }
           },
-          onSuccess: {
+          onSuccess: { image in
             DispatchQueue.main.async {
               failed = false
               shouldRefresh = false
+              loadedImage = image
             }
           },
           onSingleTap: {
@@ -80,7 +83,9 @@ public struct ImagePreviewer: View {
 
             Spacer()
 
-            ShareLink(item: url) {
+            Button {
+              shareItem = ImagePreviewShareItem(item: loadedImage ?? url)
+            } label: {
               controlLabel(systemName: "square.and.arrow.up")
             }
             .buttonBorderShape(.circle)
@@ -100,6 +105,9 @@ public struct ImagePreviewer: View {
       .ignoresSafeArea()
     }
     .navigationTransitionZoomIfAvailable(sourceID: zoomID, in: zoomNamespace)
+    .sheet(item: $shareItem) { shareItem in
+      ImagePreviewShareSheet(items: [shareItem.item])
+    }
   }
 
   private var imageOptions: SDWebImageOptions {
@@ -124,6 +132,21 @@ public struct ImagePreviewer: View {
   }
 }
 
+private struct ImagePreviewShareItem: Identifiable {
+  let id = UUID()
+  let item: Any
+}
+
+private struct ImagePreviewShareSheet: UIViewControllerRepresentable {
+  let items: [Any]
+
+  func makeUIViewController(context: Context) -> UIActivityViewController {
+    UIActivityViewController(activityItems: items, applicationActivities: nil)
+  }
+
+  func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
 private struct ZoomableImageScrollView: UIViewRepresentable {
   let url: URL
   let reloadID: UUID
@@ -131,7 +154,7 @@ private struct ZoomableImageScrollView: UIViewRepresentable {
   let maxScale: CGFloat
   let doubleTapScale: CGFloat
   let onFailure: () -> Void
-  let onSuccess: () -> Void
+  let onSuccess: (UIImage) -> Void
   let onSingleTap: () -> Void
 
   func makeCoordinator() -> ZoomableImageScrollCoordinator {
@@ -209,7 +232,7 @@ private final class ZoomableImageScrollCoordinator: NSObject, UIScrollViewDelega
       DispatchQueue.main.async {
         if let image {
           self.updateImage(image)
-          self.parent.onSuccess()
+          self.parent.onSuccess(image)
         } else {
           self.parent.onFailure()
         }

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -76,7 +76,8 @@ public struct ImagePreviewer: View {
             Button(action: {
               dismiss()
             }) {
-              controlLabel(systemName: "xmark")
+              Image(systemName: "xmark")
+                .contentShape(Circle())
             }
             .buttonBorderShape(.circle)
             .controlSize(.large)
@@ -87,7 +88,8 @@ public struct ImagePreviewer: View {
             Button {
               presentShareSheet()
             } label: {
-              controlLabel(systemName: "square.and.arrow.up")
+              Image(systemName: "square.and.arrow.up")
+                .contentShape(Circle())
             }
             .buttonBorderShape(.circle)
             .controlSize(.large)
@@ -141,13 +143,6 @@ public struct ImagePreviewer: View {
       height: 1
     )
     presenter.present(controller, animated: true)
-  }
-
-  @ViewBuilder
-  private func controlLabel(systemName: String) -> some View {
-    Image(systemName: systemName)
-      .foregroundColor(.white)
-      .contentShape(Circle())
   }
 }
 

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -75,6 +75,7 @@ public struct ImagePreviewer: View {
             }) {
               controlLabel(systemName: "xmark")
             }
+            .buttonBorderShape(.circle)
             .adaptiveButtonStyle(.borderless)
 
             Spacer()
@@ -82,6 +83,7 @@ public struct ImagePreviewer: View {
             ShareLink(item: url) {
               controlLabel(systemName: "square.and.arrow.up")
             }
+            .buttonBorderShape(.circle)
             .adaptiveButtonStyle(.borderless)
           }
           .padding(.horizontal, 16)
@@ -120,7 +122,7 @@ public struct ImagePreviewer: View {
       .font(.system(size: 14, weight: .semibold))
       .foregroundColor(.white)
       .frame(minWidth: 44, minHeight: 44)
-      .contentShape(Rectangle())
+      .contentShape(Circle())
   }
 }
 

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import LinkPresentation
 import SDWebImage
 import SDWebImageSwiftUI
 import SwiftUI
@@ -127,8 +128,9 @@ public struct ImagePreviewer: View {
       return
     }
 
+    let activityItem = ImagePreviewActivityItemSource(image: loadedImage, url: url)
     let controller = UIActivityViewController(
-      activityItems: [loadedImage ?? url],
+      activityItems: [activityItem],
       applicationActivities: nil
     )
     controller.popoverPresentationController?.sourceView = presenter.view
@@ -146,6 +148,42 @@ public struct ImagePreviewer: View {
     Image(systemName: systemName)
       .foregroundColor(.white)
       .contentShape(Circle())
+  }
+}
+
+private final class ImagePreviewActivityItemSource: NSObject, UIActivityItemSource {
+  private let image: UIImage?
+  private let url: URL
+
+  init(image: UIImage?, url: URL) {
+    self.image = image
+    self.url = url
+  }
+
+  func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController)
+    -> Any
+  {
+    image ?? url
+  }
+
+  func activityViewController(
+    _ activityViewController: UIActivityViewController,
+    itemForActivityType activityType: UIActivity.ActivityType?
+  ) -> Any? {
+    image ?? url
+  }
+
+  func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController)
+    -> LPLinkMetadata?
+  {
+    let metadata = LPLinkMetadata()
+    metadata.originalURL = url
+    metadata.url = url
+    metadata.title = url.lastPathComponent.isEmpty ? url.host : url.lastPathComponent
+    if let image {
+      metadata.imageProvider = NSItemProvider(object: image)
+    }
+    return metadata
   }
 }
 

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -78,6 +78,7 @@ public struct ImagePreviewer: View {
               controlLabel(systemName: "xmark")
             }
             .buttonBorderShape(.circle)
+            .controlSize(.large)
             .adaptiveButtonStyle(.borderless)
 
             Spacer()
@@ -88,6 +89,7 @@ public struct ImagePreviewer: View {
               controlLabel(systemName: "square.and.arrow.up")
             }
             .buttonBorderShape(.circle)
+            .controlSize(.large)
             .adaptiveButtonStyle(.borderless)
           }
           .padding(.horizontal, 16)

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -75,20 +75,15 @@ public struct ImagePreviewer: View {
             }) {
               controlLabel(systemName: "xmark")
             }
+            .adaptiveButtonStyle(.borderless)
 
             Spacer()
 
             ShareLink(item: url) {
               controlLabel(systemName: "square.and.arrow.up")
             }
-
-            Button(action: {
-              saveImage()
-            }) {
-              controlLabel(systemName: "square.and.arrow.down")
-            }
+            .adaptiveButtonStyle(.borderless)
           }
-          .buttonStyle(.plain)
           .padding(.horizontal, 16)
           .padding(.vertical, 10)
           Spacer()
@@ -103,14 +98,6 @@ public struct ImagePreviewer: View {
       .ignoresSafeArea()
     }
     .navigationTransitionZoomIfAvailable(sourceID: zoomID, in: zoomNamespace)
-  }
-
-  private func saveImage() {
-    Task {
-      guard let data = try? await URLSession.shared.data(from: url).0 else { return }
-      guard let img = UIImage(data: data) else { return }
-      UIImageWriteToSavedPhotosAlbum(img, nil, nil, nil)
-    }
   }
 
   private var imageOptions: SDWebImageOptions {
@@ -132,13 +119,8 @@ public struct ImagePreviewer: View {
     Image(systemName: systemName)
       .font(.system(size: 14, weight: .semibold))
       .foregroundColor(.white)
-      .frame(width: 34, height: 34)
-      .background {
-        Circle()
-          .fill(.ultraThinMaterial)
-          .glassEffectIfAvailable(tint: .white.opacity(0.15), shape: Circle())
-      }
-      .contentShape(Circle())
+      .frame(minWidth: 44, minHeight: 44)
+      .contentShape(Rectangle())
   }
 }
 

--- a/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
+++ b/BBCode/Sources/BBCode/Helpers/ImagePreviewer.swift
@@ -119,9 +119,7 @@ public struct ImagePreviewer: View {
   @ViewBuilder
   private func controlLabel(systemName: String) -> some View {
     Image(systemName: systemName)
-      .font(.system(size: 14, weight: .semibold))
       .foregroundColor(.white)
-      .frame(minWidth: 44, minHeight: 44)
       .contentShape(Circle())
   }
 }

--- a/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
+++ b/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
@@ -53,10 +53,16 @@ struct BBCodePreparedListItem: Identifiable {
   let blocks: [BBCodePreparedBlock]
 }
 
+struct BBCodePreparedMedia {
+  let url: URL
+  let constrainedSize: CGSize?
+  let alignment: NSTextAlignment
+}
+
 struct BBCodePreparedBlock: Identifiable {
   enum Payload {
     case text(NSAttributedString)
-    case image(URL, CGSize?)
+    case image(BBCodePreparedMedia)
     case quote([BBCodePreparedBlock])
     case list([BBCodePreparedListItem])
   }
@@ -226,19 +232,19 @@ private struct BBCodeTextKitRenderer {
   private func applyNodeWrapper(_ node: Node, to segments: [RenderedSegment]) -> [RenderedSegment] {
     switch node.type {
     case .center:
-      return mapTextSegments(segments) { attributed in
+      return mapAlignedSegments(segments, alignment: .center) { attributed in
         applyParagraphStyle(to: attributed) { style in
           style.alignment = .center
         }
       }
     case .left:
-      return mapTextSegments(segments) { attributed in
+      return mapAlignedSegments(segments, alignment: .left) { attributed in
         applyParagraphStyle(to: attributed) { style in
           style.alignment = .left
         }
       }
     case .right:
-      return mapTextSegments(segments) { attributed in
+      return mapAlignedSegments(segments, alignment: .right) { attributed in
         applyParagraphStyle(to: attributed) { style in
           style.alignment = .right
         }
@@ -254,7 +260,7 @@ private struct BBCodeTextKitRenderer {
         alignment = .left
       }
 
-      return mapTextSegments(segments) { attributed in
+      return mapAlignedSegments(segments, alignment: alignment) { attributed in
         applyParagraphStyle(to: attributed) { style in
           style.alignment = alignment
         }
@@ -370,6 +376,45 @@ private struct BBCodeTextKitRenderer {
         }
       }
     )
+  }
+
+  private func mapAlignedSegments(
+    _ segments: [RenderedSegment],
+    alignment: NSTextAlignment,
+    transform: (NSMutableAttributedString) -> Void
+  ) -> [RenderedSegment] {
+    normalizeSegments(
+      segments.map { segment in
+        switch segment {
+        case .text(let attributed):
+          let transformed = NSMutableAttributedString(attributedString: attributed)
+          transform(transformed)
+          return .text(transformed)
+        case .block(let payload):
+          return .block(alignedPayload(payload, alignment: alignment))
+        case .separator:
+          return segment
+        }
+      }
+    )
+  }
+
+  private func alignedPayload(
+    _ payload: BBCodePreparedBlock.Payload,
+    alignment: NSTextAlignment
+  ) -> BBCodePreparedBlock.Payload {
+    switch payload {
+    case .image(let media):
+      return .image(
+        BBCodePreparedMedia(
+          url: media.url,
+          constrainedSize: media.constrainedSize,
+          alignment: alignment
+        )
+      )
+    case .quote, .list, .text:
+      return payload
+    }
   }
 
   private func prefixFirstTextSegment(with prefix: String, in segments: [RenderedSegment])
@@ -554,7 +599,13 @@ private struct BBCodeTextKitRenderer {
       else {
         return nil
       }
-      return .image(url, parsedMediaSize(from: node.attr))
+      return .image(
+        BBCodePreparedMedia(
+          url: url,
+          constrainedSize: parsedMediaSize(from: node.attr),
+          alignment: .left
+        )
+      )
     case .photo:
       let path = node.renderInnerHTML(nil).trimmingCharacters(in: .whitespacesAndNewlines)
       guard !path.isEmpty,
@@ -562,7 +613,13 @@ private struct BBCodeTextKitRenderer {
       else {
         return nil
       }
-      return .image(url, parsedMediaSize(from: node.attr))
+      return .image(
+        BBCodePreparedMedia(
+          url: url,
+          constrainedSize: parsedMediaSize(from: node.attr),
+          alignment: .left
+        )
+      )
     default:
       return nil
     }

--- a/BBCode/Sources/BBCode/Views/BBCodeUIKitView.swift
+++ b/BBCode/Sources/BBCode/Views/BBCodeUIKitView.swift
@@ -87,8 +87,8 @@ final class BBCodeBlocksContainerView: UIView {
     switch block.payload {
     case .text(let attributedText):
       return BBCodeTextBlockView(attributedText: attributedText)
-    case .image(let url, let constrainedSize):
-      return BBCodeMediaBlockView(url: url, constrainedSize: constrainedSize)
+    case .image(let media):
+      return BBCodeMediaBlockView(media: media)
     case .quote(let blocks):
       return BBCodeQuoteBlockView(blocks: blocks)
     case .list(let items):
@@ -358,18 +358,18 @@ private final class AnimatedSmileyImageView: SDAnimatedImageView {
 }
 
 private final class BBCodeMediaBlockView: UIView {
-  private let url: URL
-  private let constrainedSize: CGSize?
+  private let media: BBCodePreparedMedia
   private let imageView = SDAnimatedImageView()
   private let widthConstraint: NSLayoutConstraint
   private let heightConstraint: NSLayoutConstraint
 
   private var sourceSize: CGSize?
   private var lastMeasuredWidth: CGFloat = 0
+  private var loadedThumbnailPixelSize: CGSize?
+  private var didLoadOriginalImage = false
 
-  init(url: URL, constrainedSize: CGSize?) {
-    self.url = url
-    self.constrainedSize = constrainedSize
+  init(media: BBCodePreparedMedia) {
+    self.media = media
 
     imageView.translatesAutoresizingMaskIntoConstraints = false
     imageView.contentMode = .scaleAspectFit
@@ -392,19 +392,16 @@ private final class BBCodeMediaBlockView: UIView {
     setContentHuggingPriority(.required, for: .vertical)
 
     addSubview(imageView)
-    NSLayoutConstraint.activate([
+    var constraints = [
       imageView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
-      imageView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-      imageView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
       imageView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
       widthConstraint,
       heightConstraint,
-    ])
+    ]
+    constraints.append(contentsOf: horizontalConstraints(for: media.alignment))
+    NSLayoutConstraint.activate(constraints)
 
     addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handlePreviewTap)))
-
-    sourceSize = constrainedSize
-    loadImage()
   }
 
   @available(*, unavailable)
@@ -428,8 +425,43 @@ private final class BBCodeMediaBlockView: UIView {
     }
   }
 
-  private func loadImage() {
-    imageView.sd_setImage(with: url, placeholderImage: nil, options: [.retryFailed]) {
+  private func horizontalConstraints(for alignment: NSTextAlignment) -> [NSLayoutConstraint] {
+    switch alignment {
+    case .center:
+      return [
+        imageView.centerXAnchor.constraint(equalTo: layoutMarginsGuide.centerXAnchor),
+        imageView.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor),
+        imageView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+      ]
+    case .right:
+      return [
+        imageView.leadingAnchor.constraint(greaterThanOrEqualTo: layoutMarginsGuide.leadingAnchor),
+        imageView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      ]
+    default:
+      return [
+        imageView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+        imageView.trailingAnchor.constraint(lessThanOrEqualTo: layoutMarginsGuide.trailingAnchor),
+      ]
+    }
+  }
+
+  private func loadImage(thumbnailPixelSize: CGSize) {
+    guard shouldLoadImage(for: thumbnailPixelSize) else {
+      return
+    }
+
+    loadedThumbnailPixelSize = thumbnailPixelSize
+    imageView.sd_setImage(
+      with: media.url,
+      placeholderImage: nil,
+      options: [.retryFailed],
+      context: [
+        .imageThumbnailPixelSize: NSValue(cgSize: thumbnailPixelSize),
+        .imagePreserveAspectRatio: true,
+      ],
+      progress: nil
+    ) {
       [weak self] image, _, _, _ in
       guard let self else { return }
       DispatchQueue.main.async {
@@ -441,10 +473,46 @@ private final class BBCodeMediaBlockView: UIView {
     }
   }
 
+  private func loadOriginalImageIfNeeded() {
+    guard !didLoadOriginalImage else {
+      return
+    }
+
+    didLoadOriginalImage = true
+    imageView.sd_setImage(with: media.url, placeholderImage: nil, options: [.retryFailed]) {
+      [weak self] image, _, _, _ in
+      guard let self else { return }
+      DispatchQueue.main.async {
+        if let image {
+          self.sourceSize = image.size
+        }
+        self.updateDisplayedSize(forceLayout: true)
+      }
+    }
+  }
+
+  private func shouldLoadImage(for thumbnailPixelSize: CGSize) -> Bool {
+    guard thumbnailPixelSize.width > 1, thumbnailPixelSize.height > 1 else {
+      return false
+    }
+
+    guard let loadedThumbnailPixelSize else {
+      return true
+    }
+
+    return thumbnailPixelSize.width > loadedThumbnailPixelSize.width * 1.2
+      || thumbnailPixelSize.height > loadedThumbnailPixelSize.height * 1.2
+  }
+
   private func updateDisplayedSize(forceLayout: Bool = false) {
     let horizontalInsets = directionalLayoutMargins.leading + directionalLayoutMargins.trailing
     let availableWidth = max(bounds.width - horizontalInsets, 1)
     let size = resolvedDisplaySize(maxWidth: availableWidth)
+    if shouldUseThumbnailDecode {
+      loadImage(thumbnailPixelSize: thumbnailPixelSize(for: size, maxWidth: availableWidth))
+    } else {
+      loadOriginalImageIfNeeded()
+    }
 
     if abs(widthConstraint.constant - size.width) > 0.5
       || abs(heightConstraint.constant - size.height) > 0.5
@@ -461,11 +529,11 @@ private final class BBCodeMediaBlockView: UIView {
   }
 
   private func resolvedDisplaySize(maxWidth: CGFloat) -> CGSize {
-    let fallbackSide = min(maxWidth, 120)
+    let fallbackSide = min(maxWidth, 160)
     let sourceSize = sourceSize ?? CGSize(width: fallbackSide, height: fallbackSide)
 
-    let maxDisplayWidth = min(maxWidth, constrainedSize?.width ?? maxWidth)
-    let maxDisplayHeight = constrainedSize?.height ?? CGFloat.greatestFiniteMagnitude
+    let maxDisplayWidth = min(maxWidth, media.constrainedSize?.width ?? maxWidth)
+    let maxDisplayHeight = media.constrainedSize?.height ?? CGFloat.greatestFiniteMagnitude
 
     guard sourceSize.width > 0, sourceSize.height > 0 else {
       return CGSize(width: maxDisplayWidth, height: min(maxDisplayWidth, 120))
@@ -479,6 +547,29 @@ private final class BBCodeMediaBlockView: UIView {
       width: max(1, round(sourceSize.width * scale)),
       height: max(1, round(sourceSize.height * scale))
     )
+  }
+
+  private func thumbnailPixelSize(for displaySize: CGSize, maxWidth: CGFloat) -> CGSize {
+    let scale = window?.screen.scale ?? UIScreen.main.scale
+    let targetSize: CGSize
+    if sourceSize == nil {
+      let maxDisplayWidth = min(maxWidth, media.constrainedSize?.width ?? maxWidth)
+      targetSize = CGSize(
+        width: maxDisplayWidth,
+        height: media.constrainedSize?.height ?? maxDisplayWidth
+      )
+    } else {
+      targetSize = displaySize
+    }
+
+    return CGSize(
+      width: ceil(targetSize.width * scale),
+      height: ceil(targetSize.height * scale)
+    )
+  }
+
+  private var shouldUseThumbnailDecode: Bool {
+    media.constrainedSize != nil || media.url.pathExtension.lowercased() != "svg"
   }
 
   private func invalidateAncestorLayout() {
@@ -499,7 +590,7 @@ private final class BBCodeMediaBlockView: UIView {
       return
     }
 
-    let controller = UIHostingController(rootView: ImagePreviewer(url: url))
+    let controller = UIHostingController(rootView: ImagePreviewer(url: media.url))
     controller.modalPresentationStyle = .overFullScreen
     controller.modalTransitionStyle = .crossDissolve
     controller.view.backgroundColor = .clear


### PR DESCRIPTION
## Problem
BBCode media blocks lost layout alignment when an image was wrapped by tags such as center, so text alignment worked but standalone images stayed at the leading edge. Inline image rendering also decoded large raster assets at source size, which made BBCode-heavy pages more expensive than needed.

The full-screen image preview also exposed a separate download button even though saving should be available from the share flow. Sharing only the remote URL did not reliably expose the system save-image action or a useful share sheet preview.

## Approach
Carry alignment metadata through prepared media blocks and apply it in the UIKit media view constraints. Inline raster images now request thumbnail decoding near their rendered size, while unconstrained SVG images stay on the original load path so vector badges keep their intrinsic dimensions instead of being rasterized to full width.

Simplify the image preview controls to close and share only. Both controls use the package adaptive button style so they get the system glass style on supported OS versions, keep circular button and hit-test shapes, use the large control size, and let the system button style determine icon scaling.

The preview share action now presents UIActivityViewController directly from the active UIKit presenter with a UIActivityItemSource for the loaded image. The item source supplies LinkPresentation metadata with an image provider so the native share sheet can render a preview image and expose save-image actions. It falls back to the URL only before the image is available.

## Validation
- xcodebuild -project Bangumi.xcodeproj -scheme BBCode -destination 'generic/platform=iOS Simulator' build
- xcodebuild -project Bangumi.xcodeproj -scheme Bangumi -destination 'generic/platform=iOS Simulator' build
