### PR TITLE
i18n: translate open source license labels to Chinese

### DIFF
--- a/App/Views/OpenSourceLicenseDetailView.swift
+++ b/App/Views/OpenSourceLicenseDetailView.swift
@@ -7,7 +7,7 @@ struct OpenSourceLicenseDetailView: View {
     List {
       Section {
         HStack {
-          Text("License")
+          Text("许可")
           Spacer()
           Text(license.license)
             .foregroundStyle(.secondary)
@@ -15,7 +15,7 @@ struct OpenSourceLicenseDetailView: View {
 
         Link(destination: license.sourceURL) {
           HStack {
-            Label("Source Code", systemImage: "chevron.left.forwardslash.chevron.right")
+            Label("源代码", systemImage: "chevron.left.forwardslash.chevron.right")
             Spacer()
             Image(systemName: "arrow.up.right.square")
               .font(.caption)
@@ -24,7 +24,7 @@ struct OpenSourceLicenseDetailView: View {
         }
       }
 
-      Section(header: Text("Notice")) {
+      Section(header: Text("许可声明")) {
         Text(license.notice)
           .font(.footnote.monospaced())
           .textSelection(.enabled)

--- a/App/Views/OpenSourceLicensesView.swift
+++ b/App/Views/OpenSourceLicensesView.swift
@@ -6,10 +6,10 @@ struct OpenSourceLicensesView: View {
   var body: some View {
     List {
       if licenses.isEmpty {
-        Text("No open source license data was found.")
+        Text("未找到开源许可数据。")
           .foregroundStyle(.secondary)
       } else {
-        Section(header: Text("Third-party components used by this app.")) {
+        Section(header: Text("本应用使用的第三方组件")) {
           ForEach(licenses) { license in
             NavigationLink {
               OpenSourceLicenseDetailView(license: license)
@@ -25,7 +25,7 @@ struct OpenSourceLicensesView: View {
         }
       }
     }
-    .navigationTitle("Open Source Licenses")
+    .navigationTitle("开源许可")
     .navigationBarTitleDisplayMode(.inline)
   }
 }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -221,7 +221,7 @@ struct SettingsView: View {
         NavigationLink {
           OpenSourceLicensesView()
         } label: {
-          Label("Open Source Licenses", systemImage: "doc.plaintext")
+          Label("开源许可", systemImage: "doc.plaintext")
         }
         HStack {
           Spacer()


### PR DESCRIPTION
Translate open source license related labels and hints to Chinese, including:

- Settings page: "Open Source Licenses" → "开源许可"
- License list page: nav title, section header, empty state message
- License detail page: "License" → "许可", "Source Code" → "源代码", "Notice" → "许可声明"
