### PR TITLE
fix(ui): prevent tags from overflowing subject large row card

### DIFF
--- a/App/Views/Subject/SubjectLargeRowView.swift
+++ b/App/Views/Subject/SubjectLargeRowView.swift
@@ -57,13 +57,13 @@ struct SubjectLargeRowView: View {
         HStack(spacing: 4) {
           if !subject.category.isEmpty {
             BorderView {
-              Text(subject.category).fixedSize()
+              Text(subject.category).lineLimit(1)
             }
           }
           if !subject.metaTags.isEmpty {
             ForEach(subject.metaTags, id: \.self) { tag in
               Text(tag)
-                .fixedSize()
+                .lineLimit(1)
                 .padding(2)
                 .background(.secondary.opacity(0.1))
                 .clipShape(RoundedRectangle(cornerRadius: 5))


### PR DESCRIPTION
## Summary

Tags in `SubjectLargeRowView` used `.fixedSize()` which forced each tag to maintain its full intrinsic width. With enough tags, the entire card would overflow beyond the screen.

## Fix

- Replaced `.fixedSize()` with `.lineLimit(1)` to keep each tag single-line but allow truncation
- Kept `HStack` layout; overflow tags are naturally clipped by the parent container

## Before / After

- **Before**: Cards with many tags extended past the screen edge, requiring horizontal scroll
- **After**: Card width always fits the screen; excess tags are gracefully hidden
