### PR TITLE
refactor(images): use API grid/medium for character and person thumbnails

### DIFF
--- a/App/Views/Character/CharacterLargeRowView.swift
+++ b/App/Views/Character/CharacterLargeRowView.swift
@@ -8,7 +8,7 @@ struct CharacterLargeRowView: View {
 
   var body: some View {
     HStack(spacing: 8) {
-      ImageView(img: character.images?.resize(.r200))
+      ImageView(img: character.images?.grid)
         .imageStyle(width: 90, height: 90)
         .imageType(.person)
         .imageNSFW(character.nsfw)

--- a/App/Views/Character/CharacterRelationItemView.swift
+++ b/App/Views/Character/CharacterRelationItemView.swift
@@ -13,7 +13,7 @@ struct CharacterRelationItemView: View {
     SpoilerRevealContainer(isSpoiler: item.spoiler) {
       CardView {
         HStack(alignment: .top) {
-          ImageView(img: item.character.images?.resize(.r200))
+          ImageView(img: item.character.images?.grid)
             .imageStyle(width: 60, height: 60, alignment: .top)
             .imageType(.person)
             .imageNSFW(item.character.nsfw)

--- a/App/Views/Character/CharacterRelationsView.swift
+++ b/App/Views/Character/CharacterRelationsView.swift
@@ -68,7 +68,7 @@ private struct CharacterRelationCard: View {
           .frame(maxWidth: .infinity, alignment: .center)
           .multilineTextAlignment(.center)
 
-        ImageView(img: item.character.images?.resize(.r200))
+        ImageView(img: item.character.images?.grid)
           .imageStyle(width: 72, height: 72)
           .imageType(.person)
           .imageNSFW(item.character.nsfw)

--- a/App/Views/Character/CharacterSmallView.swift
+++ b/App/Views/Character/CharacterSmallView.swift
@@ -14,7 +14,7 @@ struct CharacterSmallView: View {
   var body: some View {
     BorderView(color: .secondary.opacity(0.2), padding: 4, paddingRatio: 1, cornerRadius: 8) {
       HStack {
-        ImageView(img: character.images?.resize(.r200))
+        ImageView(img: character.images?.grid)
           .imageStyle(width: 50, height: 50)
           .imageType(.person)
           .imageNSFW(character.nsfw)

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -36,7 +36,7 @@ struct IndexRelatedItemView: View {
         case .character:
           HStack(alignment: .top) {
             if let character = item.character {
-              ImageView(img: character.images?.resize(.r200))
+              ImageView(img: character.images?.grid)
                 .imageStyle(width: 72, height: 72)
                 .imageType(.person)
                 .imageNavLink(character.link)
@@ -82,7 +82,7 @@ struct IndexRelatedItemView: View {
         case .person:
           HStack(alignment: .top) {
             if let person = item.person {
-              ImageView(img: person.images?.resize(.r200))
+              ImageView(img: person.images?.grid)
                 .imageStyle(width: 72, height: 72)
                 .imageType(.person)
                 .imageNavLink(person.link)

--- a/App/Views/Person/PersonCastItemView.swift
+++ b/App/Views/Person/PersonCastItemView.swift
@@ -8,7 +8,7 @@ struct PersonCastItemView: View {
   var body: some View {
     CardView {
       HStack(alignment: .top) {
-        ImageView(img: item.character.images?.resize(.r200))
+        ImageView(img: item.character.images?.grid)
           .imageStyle(width: 60, height: 60, alignment: .top)
           .imageType(.person)
           .imageNavLink(item.character.link)

--- a/App/Views/Person/PersonLargeRowView.swift
+++ b/App/Views/Person/PersonLargeRowView.swift
@@ -8,7 +8,7 @@ struct PersonLargeRowView: View {
 
   var body: some View {
     HStack(spacing: 8) {
-      ImageView(img: person.images?.resize(.r200))
+      ImageView(img: person.images?.grid)
         .imageStyle(width: 90, height: 90)
         .imageType(.person)
         .imageNSFW(person.nsfw)

--- a/App/Views/Person/PersonRelationItemView.swift
+++ b/App/Views/Person/PersonRelationItemView.swift
@@ -13,7 +13,7 @@ struct PersonRelationItemView: View {
     SpoilerRevealContainer(isSpoiler: item.spoiler) {
       CardView {
         HStack(alignment: .top) {
-          ImageView(img: item.person.images?.resize(.r200))
+          ImageView(img: item.person.images?.grid)
             .imageStyle(width: 60, height: 60, alignment: .top)
             .imageType(.person)
             .imageNSFW(item.person.nsfw)

--- a/App/Views/Person/PersonRelationsView.swift
+++ b/App/Views/Person/PersonRelationsView.swift
@@ -68,7 +68,7 @@ private struct PersonRelationCard: View {
           .frame(maxWidth: .infinity, alignment: .center)
           .multilineTextAlignment(.center)
 
-        ImageView(img: item.person.images?.resize(.r200))
+        ImageView(img: item.person.images?.grid)
           .imageStyle(width: 72, height: 72)
           .imageType(.person)
           .imageNSFW(item.person.nsfw)

--- a/App/Views/Person/PersonSmallView.swift
+++ b/App/Views/Person/PersonSmallView.swift
@@ -14,7 +14,7 @@ struct PersonSmallView: View {
   var body: some View {
     BorderView(color: .secondary.opacity(0.2), padding: 4, paddingRatio: 1, cornerRadius: 8) {
       HStack {
-        ImageView(img: person.images?.resize(.r200))
+        ImageView(img: person.images?.grid)
           .imageStyle(width: 50, height: 50)
           .imageType(.person)
           .imageNSFW(person.nsfw)

--- a/App/Views/Subject/SubjectCharacterListView.swift
+++ b/App/Views/Subject/SubjectCharacterListView.swift
@@ -37,7 +37,7 @@ struct SubjectCharacterListView: View {
       PageView<SubjectCharacterDTO, _>(limit: 10, reloader: reloader, nextPageFunc: load) { item in
         CardView {
           HStack {
-            ImageView(img: item.character.images?.resize(.r200))
+            ImageView(img: item.character.images?.medium)
               .imageStyle(width: 60, height: 90, alignment: .top)
               .imageType(.person)
               .imageNSFW(item.character.nsfw)

--- a/App/Views/Subject/SubjectCharactersView.swift
+++ b/App/Views/Subject/SubjectCharactersView.swift
@@ -56,7 +56,7 @@ struct CharacterCard: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 2) {
-      ImageView(img: item.character.images?.resize(.r200))
+      ImageView(img: item.character.images?.medium)
         .imageStyle(width: 72, height: 108, alignment: .top)
         .imageType(.person)
         .imageNSFW(item.character.nsfw)

--- a/App/Views/User/UserCharacterCollectionView.swift
+++ b/App/Views/User/UserCharacterCollectionView.swift
@@ -52,7 +52,7 @@ struct UserCharacterCollectionView: View {
           LazyHStack(alignment: .top) {
             ForEach(characters) { character in
               VStack {
-                ImageView(img: character.images?.resize(.r200))
+                ImageView(img: character.images?.grid)
                   .imageStyle(width: 60, height: 60)
                   .imageType(.person)
                   .imageNavLink(character.link)

--- a/App/Views/User/UserPersonCollectionView.swift
+++ b/App/Views/User/UserPersonCollectionView.swift
@@ -52,7 +52,7 @@ struct UserPersonCollectionView: View {
           LazyHStack(alignment: .top) {
             ForEach(persons) { person in
               VStack {
-                ImageView(img: person.images?.resize(.r200))
+                ImageView(img: person.images?.grid)
                   .imageStyle(width: 60, height: 60)
                   .imageType(.person)
                   .imageNavLink(person.link)


### PR DESCRIPTION
## Summary

Replace CDN resize (`r200`) with API-native cropped images for character and person thumbnails — reducing unnecessary CDN scaling and improving display quality and consistency.

## Changes

**Square thumbnails → `grid`:**
- Characters: 6 views (cards, relations, list rows, collections, etc.)
- Persons: 6 views (same)

**Portrait thumbnails → `medium`:**
- Characters: 2 views (subject character card, character list)

**Detail pages unchanged (`r400`):**
- `CharacterView` / `PersonView` continue using high-resolution resize

## Rationale

- `grid` is the API's square-grid-cropped thumbnail, a natural fit for square slots
- `medium` preserves portrait composition without cropping, suitable for vertical displays
- Avoids CDN `/r/200` scaling blur and aspect ratio issues
