### PR TITLE
refactor: migrate SwiftData models to versioned schema

### DIFF
--- a/App/Database/Mock.swift
+++ b/App/Database/Mock.swift
@@ -2,16 +2,13 @@ import Foundation
 import SwiftData
 
 func mockContainer() -> ModelContainer {
-  let config = ModelConfiguration(isStoredInMemoryOnly: true)
+  let schema = Schema(versionedSchema: BangumiSchemaV2.self)
+  let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: true)
   let container = try! ModelContainer(
-    for: BangumiCalendar.self,
-    TrendingSubject.self,
-    Episode.self,
-    Subject.self,
-    SubjectDetail.self,
-    Character.self,
-    Person.self,
-    configurations: config)
+    for: schema,
+    migrationPlan: BangumiMigrationPlan.self,
+    configurations: [config]
+  )
   Task {
     await Chii.shared.setUp(container: container)
     await Chii.shared.setMock()

--- a/App/MainApp.swift
+++ b/App/MainApp.swift
@@ -10,24 +10,14 @@ struct MainApp: App {
   @AppStorage("appearance") var appearance: AppearanceType = .system
 
   init() {
-    let schema = Schema([
-      User.self,
-      BangumiCalendar.self,
-      TrendingSubject.self,
-      Episode.self,
-      Subject.self,
-      SubjectDetail.self,
-      Character.self,
-      Person.self,
-      ChiiGroup.self,
-      Draft.self,
-      RakuenSubjectTopicCache.self,
-      RakuenGroupTopicCache.self,
-      RakuenGroupCache.self,
-    ])
+    let schema = Schema(versionedSchema: BangumiSchemaV2.self)
     let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
     do {
-      let container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+      let container = try ModelContainer(
+        for: schema,
+        migrationPlan: BangumiMigrationPlan.self,
+        configurations: [modelConfiguration]
+      )
       sharedModelContainer = container
       configureImageSupport()
     } catch {

--- a/App/Models/Calendar+Model.swift
+++ b/App/Models/Calendar+Model.swift
@@ -1,19 +1,4 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias BangumiCalendar = BangumiCalendarV1
-
-@Model
-final class BangumiCalendarV1 {
-  @Attribute(.unique)
-  var weekday: Int
-
-  var items: [BangumiCalendarItemDTO]
-
-  init(weekday: Int, items: [BangumiCalendarItemDTO]) {
-    self.weekday = weekday
-    self.items = items
-  }
-}
+typealias BangumiCalendar = BangumiSchemaV2.BangumiCalendarV1

--- a/App/Models/Character+Model.swift
+++ b/App/Models/Character+Model.swift
@@ -1,129 +1,70 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias Character = CharacterV2
+typealias Character = BangumiSchemaV2.CharacterV2
 
-@Model
-final class CharacterV2: Searchable, Linkable {
-  @Attribute(.unique)
-  var characterId: Int
-
-  var collects: Int
-  var comment: Int
-  var images: Images?
-  var infobox: Infobox
-  var lock: Bool
-  var name: String
-  var nameCN: String
-  var nsfw: Bool
-  var role: Int
-  var summary: String
-  var info: String = ""
-  var alias: String = ""
-
-  var collectedAt: Int = 0
-
-  var casts: [CharacterCastDTO] = []
-  var relations: [CharacterRelationDTO] = []
-  var indexes: [SlimIndexDTO] = []
-
-  var roleEnum: CharacterType {
-    return CharacterType(role)
-  }
-
-  func title(with preference: TitlePreference) -> String {
-    preference.title(name: name, nameCN: nameCN)
-  }
-
-  func subtitle(with preference: TitlePreference) -> String? {
-    switch preference {
-    case .chinese:
-      return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
-    case .original:
-      return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+extension Character {
+    var roleEnum: CharacterType {
+        return CharacterType(role)
     }
-  }
 
-  var link: String {
-    return "chii://character/\(characterId)"
-  }
-
-  var slim: SlimCharacterDTO {
-    SlimCharacterDTO(
-      id: characterId,
-      images: images,
-      lock: lock,
-      name: name,
-      nameCN: nameCN,
-      nsfw: nsfw,
-      role: roleEnum,
-      info: info,
-      comment: comment
-    )
-  }
-
-  init(_ item: CharacterDTO) {
-    self.characterId = item.id
-    self.collects = item.collects
-    self.comment = item.comment
-    self.images = item.images
-    self.infobox = item.infobox.clean()
-    self.lock = item.lock
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.role = item.role.rawValue
-    self.summary = item.summary
-    self.info = item.info
-    self.alias = item.infobox.aliases.joined(separator: " ")
-    self.collectedAt = item.collectedAt ?? 0
-  }
-
-  init(_ item: SlimCharacterDTO) {
-    self.characterId = item.id
-    self.collects = 0
-    self.comment = item.comment ?? 0
-    self.images = item.images
-    self.infobox = []
-    self.lock = item.lock
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.role = item.role.rawValue
-    self.info = item.info ?? ""
-    self.summary = ""
-    self.alias = ""
-    self.collectedAt = 0
-  }
-
-  func update(_ item: CharacterDTO) {
-    if self.collects != item.collects { self.collects = item.collects }
-    if self.comment != item.comment { self.comment = item.comment }
-    if self.images != item.images { self.images = item.images }
-    if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
-    if self.lock != item.lock { self.lock = item.lock }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.role != item.role.rawValue { self.role = item.role.rawValue }
-    if self.summary != item.summary { self.summary = item.summary }
-    if self.info != item.info { self.info = item.info }
-    let aliases = item.infobox.aliases.joined(separator: " ")
-    if self.alias != aliases { self.alias = aliases }
-    if let collectedAt = item.collectedAt, self.collectedAt != collectedAt {
-      self.collectedAt = collectedAt
+    func title(with preference: TitlePreference) -> String {
+        preference.title(name: name, nameCN: nameCN)
     }
-  }
 
-  func update(_ item: SlimCharacterDTO) {
-    if let images = item.images, self.images != images { self.images = images }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.role != item.role.rawValue { self.role = item.role.rawValue }
-    if let info = item.info, self.info != info { self.info = info }
-    if let comment = item.comment, self.comment != comment { self.comment = comment }
-  }
+    func subtitle(with preference: TitlePreference) -> String? {
+        switch preference {
+        case .chinese:
+            return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
+        case .original:
+            return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+        }
+    }
+
+    var link: String {
+        return "chii://character/\(characterId)"
+    }
+
+    var slim: SlimCharacterDTO {
+        SlimCharacterDTO(
+            id: characterId,
+            images: images,
+            lock: lock,
+            name: name,
+            nameCN: nameCN,
+            nsfw: nsfw,
+            role: roleEnum,
+            info: info,
+            comment: comment
+        )
+    }
+
+    func update(_ item: CharacterDTO) {
+        if self.collects != item.collects { self.collects = item.collects }
+        if self.comment != item.comment { self.comment = item.comment }
+        if self.images != item.images { self.images = item.images }
+        if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
+        if self.lock != item.lock { self.lock = item.lock }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.role != item.role.rawValue { self.role = item.role.rawValue }
+        if self.summary != item.summary { self.summary = item.summary }
+        if self.info != item.info { self.info = item.info }
+        let aliases = item.infobox.aliases.joined(separator: " ")
+        if self.alias != aliases { self.alias = aliases }
+        if let collectedAt = item.collectedAt, self.collectedAt != collectedAt {
+            self.collectedAt = collectedAt
+        }
+    }
+
+    func update(_ item: SlimCharacterDTO) {
+        if let images = item.images, self.images != images { self.images = images }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.role != item.role.rawValue { self.role = item.role.rawValue }
+        if let info = item.info, self.info != info { self.info = info }
+        if let comment = item.comment, self.comment != comment { self.comment = comment }
+    }
 }

--- a/App/Models/Draft+Model.swift
+++ b/App/Models/Draft+Model.swift
@@ -1,26 +1,11 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias Draft = DraftV1
+typealias Draft = BangumiSchemaV2.DraftV1
 
-@Model
-final class DraftV1 {
-  var content: String
-  var type: String
-  var createdAt: Int
-  var updatedAt: Int
-
-  init(type: String, content: String) {
-    self.content = content
-    self.type = type
-    self.createdAt = Int(Date().timeIntervalSince1970)
-    self.updatedAt = Int(Date().timeIntervalSince1970)
-  }
-
-  func update(content: String) {
-    self.content = content
-    self.updatedAt = Int(Date().timeIntervalSince1970)
-  }
+extension Draft {
+    func update(content: String) {
+        self.content = content
+        self.updatedAt = Int(Date().timeIntervalSince1970)
+    }
 }

--- a/App/Models/Episode+Model.swift
+++ b/App/Models/Episode+Model.swift
@@ -3,187 +3,149 @@ import OSLog
 import SwiftData
 import SwiftUI
 
-typealias Episode = EpisodeV2
+typealias Episode = BangumiSchemaV2.EpisodeV2
 
-@Model
-final class EpisodeV2: Linkable {
-  @Attribute(.unique)
-  var episodeId: Int
-
-  var subjectId: Int
-  var type: Int
-  var sort: Float
-  var name: String
-  var nameCN: String
-  var duration: String
-  var airdate: String
-  var comment: Int
-  var desc: String
-  var disc: Int
-
-  var status: Int = 0
-  var collectedAt: Int = 0
-
-  var subject: Subject?
-
-  var typeEnum: EpisodeType {
-    return EpisodeType(type)
-  }
-
-  var collectionTypeEnum: EpisodeCollectionType {
-    return EpisodeCollectionType(status)
-  }
-
-  init(_ item: EpisodeDTO) {
-    self.episodeId = item.id
-    self.subjectId = item.subjectID
-    self.type = item.type.rawValue
-    self.sort = item.sort
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.duration = item.duration
-    self.airdate = item.airdate
-    self.comment = item.comment
-    self.desc = item.desc ?? ""
-    self.disc = item.disc
-    if let collection = item.collection {
-      self.status = collection.status
-      self.collectedAt = collection.updatedAt ?? 0
-    }
-  }
-
-  func title(with preference: TitlePreference) -> AttributedString {
-    var text = AttributedString("\(self.typeEnum.name).\(self.sort.episodeDisplay)")
-    text.foregroundColor = .secondary
-    text += AttributedString(" \(preference.title(name: name, nameCN: nameCN))")
-    return text
-  }
-
-  func titleLink(with preference: TitlePreference) -> AttributedString {
-    var text = AttributedString("\(self.typeEnum.name).\(self.sort.episodeDisplay) ")
-    text.foregroundColor = .secondary
-    text += preference.title(name: name, nameCN: nameCN).withLink(self.link)
-    return text
-  }
-
-  func subtitle(with preference: TitlePreference) -> String? {
-    switch preference {
-    case .chinese:
-      return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
-    case .original:
-      return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
-    }
-  }
-
-  var link: String {
-    return "chii://episode/\(episodeId)"
-  }
-
-  var air: Date {
-    return safeParseDate(str: airdate)
-  }
-
-  var aired: Bool {
-    return air < Date()
-  }
-
-  var waitDesc: String {
-    if air.timeIntervalSince1970 == 0 {
-      return "未知"
+extension Episode {
+    var typeEnum: EpisodeType {
+        return EpisodeType(type)
     }
 
-    let calendar = Calendar.current
-    let now = Date()
-    let components = calendar.dateComponents([.day], from: now, to: air)
-
-    if components.day == 0 {
-      return "明天"
-    } else {
-      return "\(components.day ?? 0) 天后"
+    var collectionTypeEnum: EpisodeCollectionType {
+        return EpisodeCollectionType(status)
     }
-  }
 
-  var borderColor: Color {
-    var hex = 0x666666
-    switch self.collectionTypeEnum {
-    case .none:
-      if aired {
-        hex = 0x00A8FF
-      } else {
-        hex = 0x909090
-      }
-    case .wish:
-      hex = 0xFF2293
-    case .collect:
-      hex = 0x1175a8
-    case .dropped:
-      hex = 0x666666
+    func title(with preference: TitlePreference) -> AttributedString {
+        var text = AttributedString("\(self.typeEnum.name).\(self.sort.episodeDisplay)")
+        text.foregroundColor = .secondary
+        text += AttributedString(" \(preference.title(name: name, nameCN: nameCN))")
+        return text
     }
-    return Color(hex: hex)
-  }
 
-  var backgroundColor: Color {
-    var hex = 0xCCCCCC
-    switch self.collectionTypeEnum {
-    case .none:
-      if aired {
-        hex = 0xDAEAFF
-      } else {
-        hex = 0xe0e0e0
-      }
-    case .wish:
-      hex = 0xFFADD1
-    case .collect:
-      hex = 0x4897ff
-    case .dropped:
-      hex = 0xCCCCCC
+    func titleLink(with preference: TitlePreference) -> AttributedString {
+        var text = AttributedString("\(self.typeEnum.name).\(self.sort.episodeDisplay) ")
+        text.foregroundColor = .secondary
+        text += preference.title(name: name, nameCN: nameCN).withLink(self.link)
+        return text
     }
-    return Color(hex: hex)
-  }
 
-  var textColor: Color {
-    var hex = 0xFFFFFF
-    switch self.collectionTypeEnum {
-    case .none:
-      if aired {
-        hex = 0x0066CC
-      } else {
-        hex = 0x909090
-      }
-    case .wish:
-      hex = 0xFF2293
-    case .collect:
-      hex = 0xFFFFFF
-    case .dropped:
-      hex = 0xFFFFFF
+    func subtitle(with preference: TitlePreference) -> String? {
+        switch preference {
+        case .chinese:
+            return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
+        case .original:
+            return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+        }
     }
-    return Color(hex: hex)
-  }
 
-  var trendColor: Color {
-    var opacity = 0.0
-    if comment > 0 {
-      opacity = 0.1 + 0.9 * (1.0 - exp(-Double(comment - 1) / 200.0))
+    var link: String {
+        return "chii://episode/\(episodeId)"
     }
-    return Color(hex: 0xFF8040, opacity: opacity)
-  }
 
-  func update(_ item: EpisodeDTO) {
-    if self.subjectId != item.subjectID { self.subjectId = item.subjectID }
-    if self.type != item.type.rawValue { self.type = item.type.rawValue }
-    if self.sort != item.sort { self.sort = item.sort }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.duration != item.duration { self.duration = item.duration }
-    if self.airdate != item.airdate { self.airdate = item.airdate }
-    if self.comment != item.comment { self.comment = item.comment }
-    if let desc = item.desc, !desc.isEmpty && self.desc != desc { self.desc = desc }
-    if self.disc != item.disc { self.disc = item.disc }
-    if let collection = item.collection {
-      if self.status != collection.status { self.status = collection.status }
-      if let collectedAt = collection.updatedAt, self.collectedAt != collectedAt {
-        self.collectedAt = collectedAt
-      }
+    var air: Date {
+        return safeParseDate(str: airdate)
     }
-  }
+
+    var aired: Bool {
+        return air < Date()
+    }
+
+    var waitDesc: String {
+        if air.timeIntervalSince1970 == 0 {
+            return "未知"
+        }
+
+        let calendar = Calendar.current
+        let now = Date()
+        let components = calendar.dateComponents([.day], from: now, to: air)
+
+        if components.day == 0 {
+            return "明天"
+        } else {
+            return "\(components.day ?? 0) 天后"
+        }
+    }
+
+    var borderColor: Color {
+        var hex = 0x666666
+        switch self.collectionTypeEnum {
+        case .none:
+            if aired {
+                hex = 0x00A8FF
+            } else {
+                hex = 0x909090
+            }
+        case .wish:
+            hex = 0xFF2293
+        case .collect:
+            hex = 0x1175a8
+        case .dropped:
+            hex = 0x666666
+        }
+        return Color(hex: hex)
+    }
+
+    var backgroundColor: Color {
+        var hex = 0xCCCCCC
+        switch self.collectionTypeEnum {
+        case .none:
+            if aired {
+                hex = 0xDAEAFF
+            } else {
+                hex = 0xe0e0e0
+            }
+        case .wish:
+            hex = 0xFFADD1
+        case .collect:
+            hex = 0x4897ff
+        case .dropped:
+            hex = 0xCCCCCC
+        }
+        return Color(hex: hex)
+    }
+
+    var textColor: Color {
+        var hex = 0xFFFFFF
+        switch self.collectionTypeEnum {
+        case .none:
+            if aired {
+                hex = 0x0066CC
+            } else {
+                hex = 0x909090
+            }
+        case .wish:
+            hex = 0xFF2293
+        case .collect:
+            hex = 0xFFFFFF
+        case .dropped:
+            hex = 0xFFFFFF
+        }
+        return Color(hex: hex)
+    }
+
+    var trendColor: Color {
+        var opacity = 0.0
+        if comment > 0 {
+            opacity = 0.1 + 0.9 * (1.0 - exp(-Double(comment - 1) / 200.0))
+        }
+        return Color(hex: 0xFF8040, opacity: opacity)
+    }
+
+    func update(_ item: EpisodeDTO) {
+        if self.subjectId != item.subjectID { self.subjectId = item.subjectID }
+        if self.type != item.type.rawValue { self.type = item.type.rawValue }
+        if self.sort != item.sort { self.sort = item.sort }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.duration != item.duration { self.duration = item.duration }
+        if self.airdate != item.airdate { self.airdate = item.airdate }
+        if self.comment != item.comment { self.comment = item.comment }
+        if let desc = item.desc, !desc.isEmpty && self.desc != desc { self.desc = desc }
+        if self.disc != item.disc { self.disc = item.disc }
+        if let collection = item.collection {
+            if self.status != collection.status { self.status = collection.status }
+            if let collectedAt = collection.updatedAt, self.collectedAt != collectedAt {
+                self.collectedAt = collectedAt
+            }
+        }
+    }
 }

--- a/App/Models/Group+Model.swift
+++ b/App/Models/Group+Model.swift
@@ -1,108 +1,60 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias ChiiGroup = GroupV2
+typealias ChiiGroup = BangumiSchemaV2.GroupV2
 
-@Model
-final class GroupV2: Linkable {
-  @Attribute(.unique)
-  var groupId: Int
-
-  var name: String
-  var nsfw: Bool
-  var title: String
-  var icon: Avatar?
-  var creator: SlimUserDTO?
-  var creatorID: Int
-  var desc: String
-  var cat: Int
-  var accessible: Bool
-  var members: Int
-  var posts: Int
-  var topics: Int
-  var createdAt: Int
-
-  /// membership
-  var role: Int = -1
-  var joinedAt: Int = 0
-
-  /// details
-  var moderators: [GroupMemberDTO] = []
-  var recentMembers: [GroupMemberDTO] = []
-  var recentTopics: [TopicDTO] = []
-
-  var link: String {
-    return "chii://group/\(name)"
-  }
-
-  var slim: SlimGroupDTO {
-    SlimGroupDTO(
-      id: groupId,
-      name: name,
-      nsfw: nsfw,
-      title: title,
-      icon: icon,
-      creatorID: creatorID,
-      members: members,
-      createdAt: createdAt,
-      accessible: accessible
-    )
-  }
-
-  var memberRole: GroupMemberRole {
-    return GroupMemberRole(rawValue: role) ?? .guest
-  }
-
-  var canCreateTopic: Bool {
-    if accessible {
-      return true
+extension ChiiGroup {
+    var link: String {
+        return "chii://group/\(name)"
     }
-    switch memberRole {
-    case .member, .moderator, .creator:
-      return true
-    default:
-      return false
+
+    var slim: SlimGroupDTO {
+        SlimGroupDTO(
+            id: groupId,
+            name: name,
+            nsfw: nsfw,
+            title: title,
+            icon: icon,
+            creatorID: creatorID,
+            members: members,
+            createdAt: createdAt,
+            accessible: accessible
+        )
     }
-  }
 
-  init(_ item: GroupDTO) {
-    self.groupId = item.id
-    self.name = item.name
-    self.nsfw = item.nsfw
-    self.title = item.title
-    self.icon = item.icon
-    self.creator = item.creator
-    self.creatorID = item.creatorID
-    self.desc = item.description
-    self.cat = item.cat
-    self.accessible = item.accessible
-    self.members = item.members
-    self.posts = item.posts
-    self.topics = item.topics
-    self.createdAt = item.createdAt
-    self.role = item.membership?.role?.rawValue ?? -1
-    self.joinedAt = item.membership?.joinedAt ?? 0
-  }
+    var memberRole: GroupMemberRole {
+        return GroupMemberRole(rawValue: role) ?? .guest
+    }
 
-  func update(_ item: GroupDTO) {
-    if self.name != item.name { self.name = item.name }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.title != item.title { self.title = item.title }
-    if self.icon != item.icon { self.icon = item.icon }
-    if self.creator != item.creator { self.creator = item.creator }
-    if self.creatorID != item.creatorID { self.creatorID = item.creatorID }
-    if self.desc != item.description { self.desc = item.description }
-    if self.cat != item.cat { self.cat = item.cat }
-    if self.accessible != item.accessible { self.accessible = item.accessible }
-    if self.members != item.members { self.members = item.members }
-    if self.posts != item.posts { self.posts = item.posts }
-    if self.topics != item.topics { self.topics = item.topics }
-    if self.createdAt != item.createdAt { self.createdAt = item.createdAt }
-    let joinedAt = item.membership?.joinedAt ?? 0
-    if self.joinedAt != joinedAt { self.joinedAt = joinedAt }
-    let role = item.membership?.role?.rawValue ?? -1
-    if self.role != role { self.role = role }
-  }
+    var canCreateTopic: Bool {
+        if accessible {
+            return true
+        }
+        switch memberRole {
+        case .member, .moderator, .creator:
+            return true
+        default:
+            return false
+        }
+    }
+
+    func update(_ item: GroupDTO) {
+        if self.name != item.name { self.name = item.name }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.title != item.title { self.title = item.title }
+        if self.icon != item.icon { self.icon = item.icon }
+        if self.creator != item.creator { self.creator = item.creator }
+        if self.creatorID != item.creatorID { self.creatorID = item.creatorID }
+        if self.desc != item.description { self.desc = item.description }
+        if self.cat != item.cat { self.cat = item.cat }
+        if self.accessible != item.accessible { self.accessible = item.accessible }
+        if self.members != item.members { self.members = item.members }
+        if self.posts != item.posts { self.posts = item.posts }
+        if self.topics != item.topics { self.topics = item.topics }
+        if self.createdAt != item.createdAt { self.createdAt = item.createdAt }
+        let joinedAt = item.membership?.joinedAt ?? 0
+        if self.joinedAt != joinedAt { self.joinedAt = joinedAt }
+        let role = item.membership?.role?.rawValue ?? -1
+        if self.role != role { self.role = role }
+    }
 }

--- a/App/Models/Person+Model.swift
+++ b/App/Models/Person+Model.swift
@@ -1,137 +1,74 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias Person = PersonV2
+typealias Person = BangumiSchemaV2.PersonV2
 
-@Model
-final class PersonV2: Searchable, Linkable {
-  @Attribute(.unique)
-  var personId: Int
-
-  var career: [String]
-  var collects: Int
-  var comment: Int
-  var images: Images?
-  var infobox: Infobox
-  var lock: Bool
-  var name: String
-  var nameCN: String
-  var nsfw: Bool
-  var summary: String
-  var type: Int
-  var info: String = ""
-  var alias: String = ""
-
-  var collectedAt: Int = 0
-
-  var casts: [PersonCastDTO] = []
-  var works: [PersonWorkDTO] = []
-  var relations: [PersonRelationDTO] = []
-  var indexes: [SlimIndexDTO] = []
-
-  var typeEnum: PersonType {
-    return PersonType(type)
-  }
-
-  func title(with preference: TitlePreference) -> String {
-    preference.title(name: name, nameCN: nameCN)
-  }
-
-  func subtitle(with preference: TitlePreference) -> String? {
-    switch preference {
-    case .chinese:
-      return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
-    case .original:
-      return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+extension Person {
+    var typeEnum: PersonType {
+        return PersonType(type)
     }
-  }
 
-  var link: String {
-    return "chii://person/\(personId)"
-  }
-
-  var slim: SlimPersonDTO {
-    SlimPersonDTO(
-      id: personId,
-      name: name,
-      nameCN: nameCN,
-      type: typeEnum,
-      career: career.compactMap { PersonCareer(rawValue: $0) },
-      images: images,
-      lock: lock,
-      nsfw: nsfw,
-      comment: comment,
-      info: info
-    )
-  }
-
-  init(_ item: PersonDTO) {
-    self.personId = item.id
-    self.career = item.career.map(\.rawValue)
-    self.collects = item.collects
-    self.comment = item.comment
-    self.images = item.images
-    self.infobox = item.infobox.clean()
-    self.lock = item.lock
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.summary = item.summary
-    self.type = item.type.rawValue
-    self.info = item.info
-    self.alias = item.infobox.aliases.joined(separator: " ")
-    self.collectedAt = item.collectedAt ?? 0
-  }
-
-  init(_ item: SlimPersonDTO) {
-    self.personId = item.id
-    self.career = []
-    self.collects = 0
-    self.comment = item.comment ?? 0
-    self.images = item.images
-    self.infobox = []
-    self.lock = item.lock
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.summary = ""
-    self.info = item.info ?? ""
-    self.type = item.type.rawValue
-    self.alias = ""
-    self.collectedAt = 0
-  }
-
-  func update(_ item: PersonDTO) {
-    let newCareer = item.career.map(\.rawValue)
-    if self.career != newCareer { self.career = newCareer }
-    if self.collects != item.collects { self.collects = item.collects }
-    if self.comment != item.comment { self.comment = item.comment }
-    if self.images != item.images { self.images = item.images }
-    if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
-    if self.lock != item.lock { self.lock = item.lock }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.summary != item.summary { self.summary = item.summary }
-    if self.type != item.type.rawValue { self.type = item.type.rawValue }
-    if self.info != item.info { self.info = item.info }
-    let aliases = item.infobox.aliases.joined(separator: " ")
-    if self.alias != aliases { self.alias = aliases }
-    if let collectedAt = item.collectedAt, self.collectedAt != collectedAt {
-      self.collectedAt = collectedAt
+    func title(with preference: TitlePreference) -> String {
+        preference.title(name: name, nameCN: nameCN)
     }
-  }
 
-  func update(_ item: SlimPersonDTO) {
-    if let images = item.images, self.images != images { self.images = images }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if let comment = item.comment, self.comment != comment { self.comment = comment }
-    if self.type != item.type.rawValue { self.type = item.type.rawValue }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.lock != item.lock { self.lock = item.lock }
-    if let info = item.info, self.info != info { self.info = info }
-  }
+    func subtitle(with preference: TitlePreference) -> String? {
+        switch preference {
+        case .chinese:
+            return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
+        case .original:
+            return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+        }
+    }
+
+    var link: String {
+        return "chii://person/\(personId)"
+    }
+
+    var slim: SlimPersonDTO {
+        SlimPersonDTO(
+            id: personId,
+            name: name,
+            nameCN: nameCN,
+            type: typeEnum,
+            career: career.compactMap { PersonCareer(rawValue: $0) },
+            images: images,
+            lock: lock,
+            nsfw: nsfw,
+            comment: comment,
+            info: info
+        )
+    }
+
+    func update(_ item: PersonDTO) {
+        let newCareer = item.career.map(\.rawValue)
+        if self.career != newCareer { self.career = newCareer }
+        if self.collects != item.collects { self.collects = item.collects }
+        if self.comment != item.comment { self.comment = item.comment }
+        if self.images != item.images { self.images = item.images }
+        if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
+        if self.lock != item.lock { self.lock = item.lock }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.summary != item.summary { self.summary = item.summary }
+        if self.type != item.type.rawValue { self.type = item.type.rawValue }
+        if self.info != item.info { self.info = item.info }
+        let aliases = item.infobox.aliases.joined(separator: " ")
+        if self.alias != aliases { self.alias = aliases }
+        if let collectedAt = item.collectedAt, self.collectedAt != collectedAt {
+            self.collectedAt = collectedAt
+        }
+    }
+
+    func update(_ item: SlimPersonDTO) {
+        if let images = item.images, self.images != images { self.images = images }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if let comment = item.comment, self.comment != comment { self.comment = comment }
+        if self.type != item.type.rawValue { self.type = item.type.rawValue }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.lock != item.lock { self.lock = item.lock }
+        if let info = item.info, self.info != info { self.info = info }
+    }
 }

--- a/App/Models/RakuenTopic+Model.swift
+++ b/App/Models/RakuenTopic+Model.swift
@@ -1,54 +1,6 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias RakuenSubjectTopicCache = RakuenSubjectTopicCacheV1
-typealias RakuenGroupTopicCache = RakuenGroupTopicCacheV1
-
-@Model
-final class RakuenSubjectTopicCacheV1 {
-  @Attribute(.unique)
-  var mode: String
-
-  var items: [SubjectTopicDTO]
-  var updatedAt: Date
-
-  init(mode: String, items: [SubjectTopicDTO]) {
-    self.mode = mode
-    self.items = items
-    self.updatedAt = Date()
-  }
-}
-
-@Model
-final class RakuenGroupTopicCacheV1 {
-  @Attribute(.unique)
-  var mode: String
-
-  var items: [GroupTopicDTO]
-  var updatedAt: Date
-
-  init(mode: String, items: [GroupTopicDTO]) {
-    self.mode = mode
-    self.items = items
-    self.updatedAt = Date()
-  }
-}
-
-typealias RakuenGroupCache = RakuenGroupCacheV1
-
-@Model
-final class RakuenGroupCacheV1 {
-  @Attribute(.unique)
-  var id: String
-
-  var items: [SlimGroupDTO]
-  var updatedAt: Date
-
-  init(id: String, items: [SlimGroupDTO]) {
-    self.id = id
-    self.items = items
-    self.updatedAt = Date()
-  }
-}
+typealias RakuenSubjectTopicCache = BangumiSchemaV2.RakuenSubjectTopicCacheV1
+typealias RakuenGroupTopicCache = BangumiSchemaV2.RakuenGroupTopicCacheV1
+typealias RakuenGroupCache = BangumiSchemaV2.RakuenGroupCacheV1

--- a/App/Models/Schema/BangumiMigrationPlan.swift
+++ b/App/Models/Schema/BangumiMigrationPlan.swift
@@ -1,0 +1,11 @@
+import SwiftData
+
+enum BangumiMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [BangumiSchemaV2.self]
+    }
+
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/App/Models/Schema/BangumiSchemaV2.swift
+++ b/App/Models/Schema/BangumiSchemaV2.swift
@@ -1,0 +1,489 @@
+import Foundation
+import SwiftData
+
+enum BangumiSchemaV2: VersionedSchema {
+    static var versionIdentifier: Schema.Version {
+        Schema.Version(2, 0, 0)
+    }
+
+    static var models: [any PersistentModel.Type] {
+        [
+            BangumiSchemaV2.SubjectV2.self,
+            BangumiSchemaV2.EpisodeV2.self,
+            BangumiSchemaV2.CharacterV2.self,
+            BangumiSchemaV2.PersonV2.self,
+            BangumiSchemaV2.GroupV2.self,
+            BangumiSchemaV2.UserV1.self,
+            BangumiSchemaV2.DraftV1.self,
+            BangumiSchemaV2.TrendingSubjectV1.self,
+            BangumiSchemaV2.BangumiCalendarV1.self,
+            BangumiSchemaV2.SubjectDetailV1.self,
+            BangumiSchemaV2.RakuenSubjectTopicCacheV1.self,
+            BangumiSchemaV2.RakuenGroupTopicCacheV1.self,
+            BangumiSchemaV2.RakuenGroupCacheV1.self,
+        ]
+    }
+
+    // MARK: - SubjectV2
+
+    @Model
+    final class SubjectV2: Searchable, Linkable {
+        @Attribute(.unique)
+        var subjectId: Int
+
+        var airtime: SubjectAirtime
+        var collection: SubjectCollection
+        var eps: Int
+        var images: SubjectImages?
+        var infobox: Infobox
+        var locked: Bool
+        var metaTags: [String]
+        var tags: [Tag]
+        var name: String
+        var nameCN: String
+        var nsfw: Bool
+        var platform: SubjectPlatform
+        var rating: SubjectRating
+        var series: Bool
+        var summary: String
+        var type: Int
+        var volumes: Int
+        var info: String = ""
+        var alias: String = ""
+
+        var ctype: Int = 0
+        var collectedAt: Int = 0
+        var interest: SubjectInterest?
+
+        @Relationship(deleteRule: .cascade)
+        var detail: SubjectDetail?
+
+        init(_ item: SubjectDTO) {
+            self.subjectId = item.id
+            self.airtime = item.airtime
+            self.collection = item.collection
+            self.eps = item.eps
+            self.images = item.images
+            self.infobox = item.infobox.clean()
+            self.info = item.info
+            self.locked = item.locked
+            self.metaTags = item.metaTags
+            self.tags = item.tags
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.platform = item.platform
+            self.rating = item.rating
+            self.series = item.series
+            self.summary = item.summary
+            self.type = item.type.rawValue
+            self.volumes = item.volumes
+            self.interest = item.interest
+            if let interest = item.interest {
+                self.ctype = interest.type.rawValue
+                self.collectedAt = interest.updatedAt
+            }
+            self.alias = item.infobox.aliases.joined(separator: " ")
+        }
+
+        init(_ item: SlimSubjectDTO) {
+            self.subjectId = item.id
+            self.airtime = SubjectAirtime(date: "")
+            self.collection = [:]
+            self.eps = 0
+            self.images = item.images
+            self.infobox = []
+            self.info = item.info ?? ""
+            self.locked = item.locked
+            self.metaTags = []
+            self.tags = []
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.platform = SubjectPlatform(name: "")
+            self.rating = item.rating ?? SubjectRating()
+            self.series = false
+            self.summary = ""
+            self.type = item.type.rawValue
+            self.volumes = 0
+            self.alias = ""
+            self.interest = nil
+        }
+    }
+
+    // MARK: - EpisodeV2
+
+    @Model
+    final class EpisodeV2: Linkable {
+        @Attribute(.unique)
+        var episodeId: Int
+
+        var subjectId: Int
+        var type: Int
+        var sort: Float
+        var name: String
+        var nameCN: String
+        var duration: String
+        var airdate: String
+        var comment: Int
+        var desc: String
+        var disc: Int
+
+        var status: Int = 0
+        var collectedAt: Int = 0
+
+        var subject: Subject?
+
+        init(_ item: EpisodeDTO) {
+            self.episodeId = item.id
+            self.subjectId = item.subjectID
+            self.type = item.type.rawValue
+            self.sort = item.sort
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.duration = item.duration
+            self.airdate = item.airdate
+            self.comment = item.comment
+            self.desc = item.desc ?? ""
+            self.disc = item.disc
+            if let collection = item.collection {
+                self.status = collection.status
+                self.collectedAt = collection.updatedAt ?? 0
+            }
+        }
+    }
+
+    // MARK: - CharacterV2
+
+    @Model
+    final class CharacterV2: Searchable, Linkable {
+        @Attribute(.unique)
+        var characterId: Int
+
+        var collects: Int
+        var comment: Int
+        var images: Images?
+        var infobox: Infobox
+        var lock: Bool
+        var name: String
+        var nameCN: String
+        var nsfw: Bool
+        var role: Int
+        var summary: String
+        var info: String = ""
+        var alias: String = ""
+
+        var collectedAt: Int = 0
+
+        var casts: [CharacterCastDTO] = []
+        var relations: [CharacterRelationDTO] = []
+        var indexes: [SlimIndexDTO] = []
+
+        init(_ item: CharacterDTO) {
+            self.characterId = item.id
+            self.collects = item.collects
+            self.comment = item.comment
+            self.images = item.images
+            self.infobox = item.infobox.clean()
+            self.lock = item.lock
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.role = item.role.rawValue
+            self.summary = item.summary
+            self.info = item.info
+            self.alias = item.infobox.aliases.joined(separator: " ")
+            self.collectedAt = item.collectedAt ?? 0
+        }
+
+        init(_ item: SlimCharacterDTO) {
+            self.characterId = item.id
+            self.collects = 0
+            self.comment = item.comment ?? 0
+            self.images = item.images
+            self.infobox = []
+            self.lock = item.lock
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.role = item.role.rawValue
+            self.info = item.info ?? ""
+            self.summary = ""
+            self.alias = ""
+            self.collectedAt = 0
+        }
+    }
+
+    // MARK: - PersonV2
+
+    @Model
+    final class PersonV2: Searchable, Linkable {
+        @Attribute(.unique)
+        var personId: Int
+
+        var career: [String]
+        var collects: Int
+        var comment: Int
+        var images: Images?
+        var infobox: Infobox
+        var lock: Bool
+        var name: String
+        var nameCN: String
+        var nsfw: Bool
+        var summary: String
+        var type: Int
+        var info: String = ""
+        var alias: String = ""
+
+        var collectedAt: Int = 0
+
+        var casts: [PersonCastDTO] = []
+        var works: [PersonWorkDTO] = []
+        var relations: [PersonRelationDTO] = []
+        var indexes: [SlimIndexDTO] = []
+
+        init(_ item: PersonDTO) {
+            self.personId = item.id
+            self.career = item.career.map(\.rawValue)
+            self.collects = item.collects
+            self.comment = item.comment
+            self.images = item.images
+            self.infobox = item.infobox.clean()
+            self.lock = item.lock
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.summary = item.summary
+            self.type = item.type.rawValue
+            self.info = item.info
+            self.alias = item.infobox.aliases.joined(separator: " ")
+            self.collectedAt = item.collectedAt ?? 0
+        }
+
+        init(_ item: SlimPersonDTO) {
+            self.personId = item.id
+            self.career = []
+            self.collects = 0
+            self.comment = item.comment ?? 0
+            self.images = item.images
+            self.infobox = []
+            self.lock = item.lock
+            self.name = item.name
+            self.nameCN = item.nameCN
+            self.nsfw = item.nsfw
+            self.summary = ""
+            self.info = item.info ?? ""
+            self.type = item.type.rawValue
+            self.alias = ""
+            self.collectedAt = 0
+        }
+    }
+
+    // MARK: - GroupV2
+
+    @Model
+    final class GroupV2: Linkable {
+        @Attribute(.unique)
+        var groupId: Int
+
+        var name: String
+        var nsfw: Bool
+        var title: String
+        var icon: Avatar?
+        var creator: SlimUserDTO?
+        var creatorID: Int
+        var desc: String
+        var cat: Int
+        var accessible: Bool
+        var members: Int
+        var posts: Int
+        var topics: Int
+        var createdAt: Int
+
+        /// membership
+        var role: Int = -1
+        var joinedAt: Int = 0
+
+        /// details
+        var moderators: [GroupMemberDTO] = []
+        var recentMembers: [GroupMemberDTO] = []
+        var recentTopics: [TopicDTO] = []
+
+        init(_ item: GroupDTO) {
+            self.groupId = item.id
+            self.name = item.name
+            self.nsfw = item.nsfw
+            self.title = item.title
+            self.icon = item.icon
+            self.creator = item.creator
+            self.creatorID = item.creatorID
+            self.desc = item.description
+            self.cat = item.cat
+            self.accessible = item.accessible
+            self.members = item.members
+            self.posts = item.posts
+            self.topics = item.topics
+            self.createdAt = item.createdAt
+            self.role = item.membership?.role?.rawValue ?? -1
+            self.joinedAt = item.membership?.joinedAt ?? 0
+        }
+    }
+
+    // MARK: - UserV1
+
+    @Model
+    final class UserV1 {
+        @Attribute(.unique)
+        var userId: Int
+
+        var username: String
+        var nickname: String
+        var avatar: Avatar?
+        var group: Int
+        var joinedAt: Int
+        var sign: String
+        var site: String
+        var location: String
+        var bio: String
+        var networkServices: [UserNetworkServiceDTO]
+        var homepage: UserHomepageDTO
+        var stats: UserStatsDTO?
+
+        init(_ item: UserDTO) {
+            self.userId = item.id
+            self.username = item.username
+            self.nickname = item.nickname
+            self.avatar = item.avatar
+            self.group = item.group.rawValue
+            self.joinedAt = item.joinedAt
+            self.sign = item.sign
+            self.site = item.site
+            self.location = item.location
+            self.bio = item.bio
+            self.networkServices = item.networkServices
+            self.homepage = item.homepage
+            self.stats = item.stats
+        }
+    }
+
+    // MARK: - DraftV1
+
+    @Model
+    final class DraftV1 {
+        var content: String
+        var type: String
+        var createdAt: Int
+        var updatedAt: Int
+
+        init(type: String, content: String) {
+            self.content = content
+            self.type = type
+            self.createdAt = Int(Date().timeIntervalSince1970)
+            self.updatedAt = Int(Date().timeIntervalSince1970)
+        }
+    }
+
+    // MARK: - TrendingSubjectV1
+
+    @Model
+    final class TrendingSubjectV1 {
+        @Attribute(.unique)
+        var type: Int
+
+        var items: [TrendingSubjectDTO]
+
+        init(type: Int, items: [TrendingSubjectDTO]) {
+            self.type = type
+            self.items = items
+        }
+    }
+
+    // MARK: - BangumiCalendarV1
+
+    @Model
+    final class BangumiCalendarV1 {
+        @Attribute(.unique)
+        var weekday: Int
+
+        var items: [BangumiCalendarItemDTO]
+
+        init(weekday: Int, items: [BangumiCalendarItemDTO]) {
+            self.weekday = weekday
+            self.items = items
+        }
+    }
+
+    // MARK: - SubjectDetailV1
+
+    @Model
+    final class SubjectDetailV1 {
+        @Attribute(.unique)
+        var subjectId: Int
+
+        var positions: [SubjectPositionDTO] = []
+        var characters: [SubjectCharacterDTO] = []
+        var offprints: [SubjectRelationDTO] = []
+        var relations: [SubjectRelationDTO] = []
+        var recs: [SubjectRecDTO] = []
+        var collects: [SubjectCollectDTO] = []
+        var reviews: [SubjectReviewDTO] = []
+        var topics: [TopicDTO] = []
+        var comments: [SubjectCommentDTO] = []
+        var indexes: [SlimIndexDTO] = []
+
+        init(subjectId: Int) {
+            self.subjectId = subjectId
+        }
+    }
+
+    // MARK: - RakuenSubjectTopicCacheV1
+
+    @Model
+    final class RakuenSubjectTopicCacheV1 {
+        @Attribute(.unique)
+        var mode: String
+
+        var items: [SubjectTopicDTO]
+        var updatedAt: Date
+
+        init(mode: String, items: [SubjectTopicDTO]) {
+            self.mode = mode
+            self.items = items
+            self.updatedAt = Date()
+        }
+    }
+
+    // MARK: - RakuenGroupTopicCacheV1
+
+    @Model
+    final class RakuenGroupTopicCacheV1 {
+        @Attribute(.unique)
+        var mode: String
+
+        var items: [GroupTopicDTO]
+        var updatedAt: Date
+
+        init(mode: String, items: [GroupTopicDTO]) {
+            self.mode = mode
+            self.items = items
+            self.updatedAt = Date()
+        }
+    }
+
+    // MARK: - RakuenGroupCacheV1
+
+    @Model
+    final class RakuenGroupCacheV1 {
+        @Attribute(.unique)
+        var id: String
+
+        var items: [SlimGroupDTO]
+        var updatedAt: Date
+
+        init(id: String, items: [SlimGroupDTO]) {
+            self.id = id
+            self.items = items
+            self.updatedAt = Date()
+        }
+    }
+}

--- a/App/Models/Subject+Model.swift
+++ b/App/Models/Subject+Model.swift
@@ -1,320 +1,236 @@
 import Foundation
 import OSLog
 import SwiftData
-import SwiftUI
 
-typealias Subject = SubjectV2
+typealias Subject = BangumiSchemaV2.SubjectV2
 
-@Model
-final class SubjectV2: Searchable, Linkable {
-  @Attribute(.unique)
-  var subjectId: Int
-
-  var airtime: SubjectAirtime
-  var collection: SubjectCollection
-  var eps: Int
-  var images: SubjectImages?
-  var infobox: Infobox
-  var locked: Bool
-  var metaTags: [String]
-  var tags: [Tag]
-  var name: String
-  var nameCN: String
-  var nsfw: Bool
-  var platform: SubjectPlatform
-  var rating: SubjectRating
-  var series: Bool
-  var summary: String
-  var type: Int
-  var volumes: Int
-  var info: String = ""
-  var alias: String = ""
-
-  var ctype: Int = 0
-  var collectedAt: Int = 0
-  var interest: SubjectInterest?
-
-  @Relationship(deleteRule: .cascade)
-  var detail: SubjectDetail?
-
-  var typeEnum: SubjectType {
-    return SubjectType(type)
-  }
-
-  var ctypeEnum: CollectionType {
-    return CollectionType(ctype)
-  }
-
-  private func ensureDetail() -> SubjectDetail {
-    if let detail {
-      return detail
-    }
-    let detail = SubjectDetail(subjectId: subjectId)
-    self.detail = detail
-    return detail
-  }
-
-  var positions: [SubjectPositionDTO] {
-    get { detail?.positions ?? [] }
-    set { ensureDetail().positions = newValue }
-  }
-
-  var characters: [SubjectCharacterDTO] {
-    get { detail?.characters ?? [] }
-    set { ensureDetail().characters = newValue }
-  }
-
-  var offprints: [SubjectRelationDTO] {
-    get { detail?.offprints ?? [] }
-    set { ensureDetail().offprints = newValue }
-  }
-
-  var relations: [SubjectRelationDTO] {
-    get { detail?.relations ?? [] }
-    set { ensureDetail().relations = newValue }
-  }
-
-  var recs: [SubjectRecDTO] {
-    get { detail?.recs ?? [] }
-    set { ensureDetail().recs = newValue }
-  }
-
-  var collects: [SubjectCollectDTO] {
-    get { detail?.collects ?? [] }
-    set { ensureDetail().collects = newValue }
-  }
-
-  var reviews: [SubjectReviewDTO] {
-    get { detail?.reviews ?? [] }
-    set { ensureDetail().reviews = newValue }
-  }
-
-  var topics: [TopicDTO] {
-    get { detail?.topics ?? [] }
-    set { ensureDetail().topics = newValue }
-  }
-
-  var comments: [SubjectCommentDTO] {
-    get { detail?.comments ?? [] }
-    set { ensureDetail().comments = newValue }
-  }
-
-  var indexes: [SlimIndexDTO] {
-    get { detail?.indexes ?? [] }
-    set { ensureDetail().indexes = newValue }
-  }
-
-  func title(with preference: TitlePreference) -> String {
-    preference.title(name: name, nameCN: nameCN)
-  }
-
-  func subtitle(with preference: TitlePreference) -> String? {
-    switch preference {
-    case .chinese:
-      return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
-    case .original:
-      return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
-    }
-  }
-
-  var category: String {
-    if platform.typeCN.isEmpty {
-      return typeEnum.description
-    } else {
-      if series {
-        return "\(platform.typeCN)系列"
-      } else {
-        return platform.typeCN
-      }
-    }
-  }
-
-  var epsDesc: String {
-    return self.eps > 0 ? "\(self.eps)" : "??"
-  }
-
-  var volumesDesc: String {
-    return self.volumes > 0 ? "\(self.volumes)" : "??"
-  }
-
-  var link: String {
-    return "chii://subject/\(subjectId)"
-  }
-
-  var slim: SlimSubjectDTO {
-    SlimSubjectDTO(self)
-  }
-
-  init(_ item: SubjectDTO) {
-    self.subjectId = item.id
-    self.airtime = item.airtime
-    self.collection = item.collection
-    self.eps = item.eps
-    self.images = item.images
-    self.infobox = item.infobox.clean()
-    self.info = item.info
-    self.locked = item.locked
-    self.metaTags = item.metaTags
-    self.tags = item.tags
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.platform = item.platform
-    self.rating = item.rating
-    self.series = item.series
-    self.summary = item.summary
-    self.type = item.type.rawValue
-    self.volumes = item.volumes
-    self.interest = item.interest
-    if let interest = item.interest {
-      self.ctype = interest.type.rawValue
-      self.collectedAt = interest.updatedAt
-    }
-    self.alias = item.infobox.aliases.joined(separator: " ")
-  }
-
-  init(_ item: SlimSubjectDTO) {
-    self.subjectId = item.id
-    self.airtime = SubjectAirtime(date: "")
-    self.collection = [:]
-    self.eps = 0
-    self.images = item.images
-    self.infobox = []
-    self.info = item.info ?? ""
-    self.locked = item.locked
-    self.metaTags = []
-    self.tags = []
-    self.name = item.name
-    self.nameCN = item.nameCN
-    self.nsfw = item.nsfw
-    self.platform = SubjectPlatform(name: "")
-    self.rating = item.rating ?? SubjectRating()
-    self.series = false
-    self.summary = ""
-    self.type = item.type.rawValue
-    self.volumes = 0
-    self.alias = ""
-    self.interest = nil
-  }
-
-  func update(_ item: SubjectDTO) {
-    if self.airtime != item.airtime { self.airtime = item.airtime }
-    if self.collection != item.collection { self.collection = item.collection }
-    if self.eps != item.eps { self.eps = item.eps }
-    if let images = item.images, self.images != images { self.images = images }
-    if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
-    if self.info != item.info { self.info = item.info }
-    if self.locked != item.locked { self.locked = item.locked }
-    if self.metaTags != item.metaTags { self.metaTags = item.metaTags }
-    if self.tags != item.tags { self.tags = item.tags }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.platform != item.platform { self.platform = item.platform }
-    if self.rating != item.rating { self.rating = item.rating }
-    if self.series != item.series { self.series = item.series }
-    if self.summary != item.summary { self.summary = item.summary }
-    if self.type != item.type.rawValue { self.type = item.type.rawValue }
-    if self.volumes != item.volumes { self.volumes = item.volumes }
-    let aliases = item.infobox.aliases.joined(separator: " ")
-    if self.alias != aliases { self.alias = aliases }
-    if let interest = item.interest {
-      if self.ctype != interest.type.rawValue { self.ctype = interest.type.rawValue }
-      if self.collectedAt != interest.updatedAt { self.collectedAt = interest.updatedAt }
-      if self.interest != interest { self.interest = interest }
-    } else {
-      if self.ctype != 0 { self.ctype = 0 }
-      if self.collectedAt != 0 { self.collectedAt = 0 }
-      if self.interest != nil { self.interest = nil }
-    }
-  }
-
-  func update(_ item: SlimSubjectDTO) {
-    if let images = item.images, self.images != images { self.images = images }
-    if let info = item.info, self.info != info { self.info = info }
-    if let rating = item.rating, self.rating != rating { self.rating = rating }
-    if self.locked != item.locked { self.locked = item.locked }
-    if self.name != item.name { self.name = item.name }
-    if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
-    if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
-    if self.type != item.type.rawValue { self.type = item.type.rawValue }
-  }
-
-  func nextEpisodeDays(context: ModelContext) -> Int {
-    // 只处理动画和真人剧集
-    guard typeEnum == .anime || typeEnum == .real else {
-      return Int.max
+extension Subject {
+    var typeEnum: SubjectType {
+        return SubjectType(type)
     }
 
-    do {
-      // 查找该条目的第一个未看的主要剧集
-      let currentSubjectId = self.subjectId
-      let descriptor = FetchDescriptor<Episode>(
-        predicate: #Predicate<Episode> {
-          $0.subjectId == currentSubjectId && $0.type == 0 && $0.status == 0
-        },
-        sortBy: [SortDescriptor<Episode>(\.sort, order: .forward)]
-      )
-
-      let episodes = try context.fetch(descriptor)
-
-      // 没有未看的剧集，返回最低优先级
-      guard let nextEpisode = episodes.first else {
-        return Int.max
-      }
-
-      // 播出时间未知，返回较低优先级
-      if nextEpisode.air.timeIntervalSince1970 == 0 {
-        return Int.max - 1
-      }
-
-      // 计算与当前时间的天数差
-      let calendar = Calendar.current
-      let now = Date()
-      let episodeDate = nextEpisode.air
-
-      // 获取两个日期的开始时间
-      let nowDate = calendar.startOfDay(for: now)
-      let airDate = calendar.startOfDay(for: episodeDate)
-
-      let components = calendar.dateComponents([.day], from: nowDate, to: airDate)
-
-      if let days = components.day {
-        // 返回实际的天数差
-        return days
-      }
-      return Int.max
-    } catch {
-      return Int.max
+    var ctypeEnum: CollectionType {
+        return CollectionType(ctype)
     }
-  }
 
-  /// 用于比较两个条目的播出天数优先级
-  static func compareDays(_ days1: Int, _ days2: Int, _ subject1: Subject, _ subject2: Subject)
-    -> Bool
-  {
-    // 处理无播出时间的情况
-    if days1 >= Int.max - 1 && days2 >= Int.max - 1 {
-      // 两个都没有播出时间，按收藏时间排序
-      return subject1.collectedAt > subject2.collectedAt
-    } else if days1 >= Int.max - 1 {
-      // subject1 没有播出时间，排在后面
-      return false
-    } else if days2 >= Int.max - 1 {
-      // subject2 没有播出时间，排在后面
-      return true
-    } else if days1 < 0 && days2 >= 0 {
-      // subject1 已播出，subject2 未播出，则 subject1 优先
-      return true
-    } else if days1 >= 0 && days2 < 0 {
-      // subject1 未播出，subject2 已播出，则 subject2 优先
-      return false
-    } else if days1 < 0 && days2 < 0 {
-      // 两个都已播出，则越近播出的越优先（-1 > -2）
-      return days1 > days2
-    } else {
-      // 两个都未播出，则越早播出的越优先
-      return days1 < days2
+    private func ensureDetail() -> SubjectDetail {
+        if let detail {
+            return detail
+        }
+        let detail = SubjectDetail(subjectId: subjectId)
+        self.detail = detail
+        return detail
     }
-  }
+
+    var positions: [SubjectPositionDTO] {
+        get { detail?.positions ?? [] }
+        set { ensureDetail().positions = newValue }
+    }
+
+    var characters: [SubjectCharacterDTO] {
+        get { detail?.characters ?? [] }
+        set { ensureDetail().characters = newValue }
+    }
+
+    var offprints: [SubjectRelationDTO] {
+        get { detail?.offprints ?? [] }
+        set { ensureDetail().offprints = newValue }
+    }
+
+    var relations: [SubjectRelationDTO] {
+        get { detail?.relations ?? [] }
+        set { ensureDetail().relations = newValue }
+    }
+
+    var recs: [SubjectRecDTO] {
+        get { detail?.recs ?? [] }
+        set { ensureDetail().recs = newValue }
+    }
+
+    var collects: [SubjectCollectDTO] {
+        get { detail?.collects ?? [] }
+        set { ensureDetail().collects = newValue }
+    }
+
+    var reviews: [SubjectReviewDTO] {
+        get { detail?.reviews ?? [] }
+        set { ensureDetail().reviews = newValue }
+    }
+
+    var topics: [TopicDTO] {
+        get { detail?.topics ?? [] }
+        set { ensureDetail().topics = newValue }
+    }
+
+    var comments: [SubjectCommentDTO] {
+        get { detail?.comments ?? [] }
+        set { ensureDetail().comments = newValue }
+    }
+
+    var indexes: [SlimIndexDTO] {
+        get { detail?.indexes ?? [] }
+        set { ensureDetail().indexes = newValue }
+    }
+
+    func title(with preference: TitlePreference) -> String {
+        preference.title(name: name, nameCN: nameCN)
+    }
+
+    func subtitle(with preference: TitlePreference) -> String? {
+        switch preference {
+        case .chinese:
+            return nameCN.isEmpty ? nil : (name != nameCN ? name : nil)
+        case .original:
+            return name.isEmpty ? nil : (nameCN != name && !nameCN.isEmpty ? nameCN : nil)
+        }
+    }
+
+    var category: String {
+        if platform.typeCN.isEmpty {
+            return typeEnum.description
+        } else {
+            if series {
+                return "\(platform.typeCN)系列"
+            } else {
+                return platform.typeCN
+            }
+        }
+    }
+
+    var epsDesc: String {
+        return self.eps > 0 ? "\(self.eps)" : "??"
+    }
+
+    var volumesDesc: String {
+        return self.volumes > 0 ? "\(self.volumes)" : "??"
+    }
+
+    var link: String {
+        return "chii://subject/\(subjectId)"
+    }
+
+    var slim: SlimSubjectDTO {
+        SlimSubjectDTO(self)
+    }
+
+    func update(_ item: SubjectDTO) {
+        if self.airtime != item.airtime { self.airtime = item.airtime }
+        if self.collection != item.collection { self.collection = item.collection }
+        if self.eps != item.eps { self.eps = item.eps }
+        if let images = item.images, self.images != images { self.images = images }
+        if self.infobox != item.infobox.clean() { self.infobox = item.infobox.clean() }
+        if self.info != item.info { self.info = item.info }
+        if self.locked != item.locked { self.locked = item.locked }
+        if self.metaTags != item.metaTags { self.metaTags = item.metaTags }
+        if self.tags != item.tags { self.tags = item.tags }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.platform != item.platform { self.platform = item.platform }
+        if self.rating != item.rating { self.rating = item.rating }
+        if self.series != item.series { self.series = item.series }
+        if self.summary != item.summary { self.summary = item.summary }
+        if self.type != item.type.rawValue { self.type = item.type.rawValue }
+        if self.volumes != item.volumes { self.volumes = item.volumes }
+        let aliases = item.infobox.aliases.joined(separator: " ")
+        if self.alias != aliases { self.alias = aliases }
+        if let interest = item.interest {
+            if self.ctype != interest.type.rawValue { self.ctype = interest.type.rawValue }
+            if self.collectedAt != interest.updatedAt { self.collectedAt = interest.updatedAt }
+            if self.interest != interest { self.interest = interest }
+        } else {
+            if self.ctype != 0 { self.ctype = 0 }
+            if self.collectedAt != 0 { self.collectedAt = 0 }
+            if self.interest != nil { self.interest = nil }
+        }
+    }
+
+    func update(_ item: SlimSubjectDTO) {
+        if let images = item.images, self.images != images { self.images = images }
+        if let info = item.info, self.info != info { self.info = info }
+        if let rating = item.rating, self.rating != rating { self.rating = rating }
+        if self.locked != item.locked { self.locked = item.locked }
+        if self.name != item.name { self.name = item.name }
+        if self.nameCN != item.nameCN { self.nameCN = item.nameCN }
+        if self.nsfw != item.nsfw { self.nsfw = item.nsfw }
+        if self.type != item.type.rawValue { self.type = item.type.rawValue }
+    }
+
+    func nextEpisodeDays(context: ModelContext) -> Int {
+        // 只处理动画和真人剧集
+        guard typeEnum == .anime || typeEnum == .real else {
+            return Int.max
+        }
+
+        do {
+            // 查找该条目的第一个未看的主要剧集
+            let currentSubjectId = self.subjectId
+            let descriptor = FetchDescriptor<Episode>(
+                predicate: #Predicate<Episode> {
+                    $0.subjectId == currentSubjectId && $0.type == 0 && $0.status == 0
+                },
+                sortBy: [SortDescriptor<Episode>(\.sort, order: .forward)]
+            )
+
+            let episodes = try context.fetch(descriptor)
+
+            // 没有未看的剧集，返回最低优先级
+            guard let nextEpisode = episodes.first else {
+                return Int.max
+            }
+
+            // 播出时间未知，返回较低优先级
+            if nextEpisode.air.timeIntervalSince1970 == 0 {
+                return Int.max - 1
+            }
+
+            // 计算与当前时间的天数差
+            let calendar = Calendar.current
+            let now = Date()
+            let episodeDate = nextEpisode.air
+
+            // 获取两个日期的开始时间
+            let nowDate = calendar.startOfDay(for: now)
+            let airDate = calendar.startOfDay(for: episodeDate)
+
+            let components = calendar.dateComponents([.day], from: nowDate, to: airDate)
+
+            if let days = components.day {
+                // 返回实际的天数差
+                return days
+            }
+            return Int.max
+        } catch {
+            return Int.max
+        }
+    }
+
+    /// 用于比较两个条目的播出天数优先级
+    static func compareDays(_ days1: Int, _ days2: Int, _ subject1: Subject, _ subject2: Subject)
+        -> Bool
+    {
+        // 处理无播出时间的情况
+        if days1 >= Int.max - 1 && days2 >= Int.max - 1 {
+            // 两个都没有播出时间，按收藏时间排序
+            return subject1.collectedAt > subject2.collectedAt
+        } else if days1 >= Int.max - 1 {
+            // subject1 没有播出时间，排在后面
+            return false
+        } else if days2 >= Int.max - 1 {
+            // subject2 没有播出时间，排在后面
+            return true
+        } else if days1 < 0 && days2 >= 0 {
+            // subject1 已播出，subject2 未播出，则 subject1 优先
+            return true
+        } else if days1 >= 0 && days2 < 0 {
+            // subject1 未播出，subject2 已播出，则 subject2 优先
+            return false
+        } else if days1 < 0 && days2 < 0 {
+            // 两个都已播出，则越近播出的越优先（-1 > -2）
+            return days1 > days2
+        } else {
+            // 两个都未播出，则越早播出的越优先
+            return days1 < days2
+        }
+    }
 }

--- a/App/Models/SubjectDetail+Model.swift
+++ b/App/Models/SubjectDetail+Model.swift
@@ -1,25 +1,4 @@
 import Foundation
 import SwiftData
 
-typealias SubjectDetail = SubjectDetailV1
-
-@Model
-final class SubjectDetailV1 {
-  @Attribute(.unique)
-  var subjectId: Int
-
-  var positions: [SubjectPositionDTO] = []
-  var characters: [SubjectCharacterDTO] = []
-  var offprints: [SubjectRelationDTO] = []
-  var relations: [SubjectRelationDTO] = []
-  var recs: [SubjectRecDTO] = []
-  var collects: [SubjectCollectDTO] = []
-  var reviews: [SubjectReviewDTO] = []
-  var topics: [TopicDTO] = []
-  var comments: [SubjectCommentDTO] = []
-  var indexes: [SlimIndexDTO] = []
-
-  init(subjectId: Int) {
-    self.subjectId = subjectId
-  }
-}
+typealias SubjectDetail = BangumiSchemaV2.SubjectDetailV1

--- a/App/Models/Trending+Model.swift
+++ b/App/Models/Trending+Model.swift
@@ -1,19 +1,4 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias TrendingSubject = TrendingSubjectV1
-
-@Model
-final class TrendingSubjectV1 {
-  @Attribute(.unique)
-  var type: Int
-
-  var items: [TrendingSubjectDTO]
-
-  init(type: Int, items: [TrendingSubjectDTO]) {
-    self.type = type
-    self.items = items
-  }
-}
+typealias TrendingSubject = BangumiSchemaV2.TrendingSubjectV1

--- a/App/Models/User+Model.swift
+++ b/App/Models/User+Model.swift
@@ -1,72 +1,37 @@
 import Foundation
-import OSLog
 import SwiftData
-import SwiftUI
 
-typealias User = UserV1
+typealias User = BangumiSchemaV2.UserV1
 
-@Model
-final class UserV1 {
-  @Attribute(.unique)
-  var userId: Int
+extension User {
+    var name: String {
+        nickname.isEmpty ? "用户\(username)" : nickname
+    }
 
-  var username: String
-  var nickname: String
-  var avatar: Avatar?
-  var group: Int
-  var joinedAt: Int
-  var sign: String
-  var site: String
-  var location: String
-  var bio: String
-  var networkServices: [UserNetworkServiceDTO]
-  var homepage: UserHomepageDTO
-  var stats: UserStatsDTO?
+    var groupEnum: UserGroup {
+        UserGroup(group)
+    }
 
-  var name: String {
-    nickname.isEmpty ? "用户\(username)" : nickname
-  }
+    var link: String {
+        "chii://user/\(username)"
+    }
 
-  var groupEnum: UserGroup {
-    UserGroup(group)
-  }
+    var slim: SlimUserDTO {
+        SlimUserDTO(self)
+    }
 
-  var link: String {
-    "chii://user/\(username)"
-  }
-
-  var slim: SlimUserDTO {
-    SlimUserDTO(self)
-  }
-
-  init(_ item: UserDTO) {
-    self.userId = item.id
-    self.username = item.username
-    self.nickname = item.nickname
-    self.avatar = item.avatar
-    self.group = item.group.rawValue
-    self.joinedAt = item.joinedAt
-    self.sign = item.sign
-    self.site = item.site
-    self.location = item.location
-    self.bio = item.bio
-    self.networkServices = item.networkServices
-    self.homepage = item.homepage
-    self.stats = item.stats
-  }
-
-  func update(_ item: UserDTO) {
-    if self.username != item.username { self.username = item.username }
-    if self.nickname != item.nickname { self.nickname = item.nickname }
-    if self.avatar != item.avatar { self.avatar = item.avatar }
-    if self.group != item.group.rawValue { self.group = item.group.rawValue }
-    if self.joinedAt != item.joinedAt { self.joinedAt = item.joinedAt }
-    if self.sign != item.sign { self.sign = item.sign }
-    if self.site != item.site { self.site = item.site }
-    if self.location != item.location { self.location = item.location }
-    if self.bio != item.bio { self.bio = item.bio }
-    if self.networkServices != item.networkServices { self.networkServices = item.networkServices }
-    if self.homepage != item.homepage { self.homepage = item.homepage }
-    if self.stats != item.stats { self.stats = item.stats }
-  }
+    func update(_ item: UserDTO) {
+        if self.username != item.username { self.username = item.username }
+        if self.nickname != item.nickname { self.nickname = item.nickname }
+        if self.avatar != item.avatar { self.avatar = item.avatar }
+        if self.group != item.group.rawValue { self.group = item.group.rawValue }
+        if self.joinedAt != item.joinedAt { self.joinedAt = item.joinedAt }
+        if self.sign != item.sign { self.sign = item.sign }
+        if self.site != item.site { self.site = item.site }
+        if self.location != item.location { self.location = item.location }
+        if self.bio != item.bio { self.bio = item.bio }
+        if self.networkServices != item.networkServices { self.networkServices = item.networkServices }
+        if self.homepage != item.homepage { self.homepage = item.homepage }
+        if self.stats != item.stats { self.stats = item.stats }
+    }
 }


### PR DESCRIPTION
## Summary

Migrate all SwiftData `@Model` classes into a versioned schema (`BangumiSchemaV2`) following the pattern established in KMReader.

## Motivation

The project currently has no `VersionedSchema`, `MigrationPlan`, or any migration infrastructure. Models are named with manual `V1`/`V2` suffixes and the container is created with a flat `Schema([...])` array. This makes it impossible to safely evolve the schema over time.

## Changes

- **New: `App/Models/Schema/BangumiSchemaV2.swift`** — `VersionedSchema` enum containing all 13 `@Model` classes with only stored properties and designated initializers
- **New: `App/Models/Schema/BangumiMigrationPlan.swift`** — base `SchemaMigrationPlan` with V2 as the starting point
- **Updated: all `App/Models/*+Model.swift`** — typealiases now point to `BangumiSchemaV2.Xxx`; computed properties and methods moved into extensions on the typealiases
- **Updated: `App/MainApp.swift`** — uses `Schema(versionedSchema:)` with migration plan
- **Updated: `App/Database/Mock.swift`** — uses versioned schema for previews

## Design

- **Schema file = data definition only** (stored properties + inits)
- **Model files = typealias + domain logic extensions** (computed vars, update methods, helpers)
- Completely non-breaking: all existing code uses typealiases (`Subject`, `Episode`, etc.) which resolve transparently
- When adding new properties in the future, create `BangumiSchemaV3` with updated models and add a migration stage — no changes needed in extension files
