### PR TITLE
fix: refresh calendar views after day changes

### DIFF
--- a/App/Views/Discover/CalendarSlimView.swift
+++ b/App/Views/Discover/CalendarSlimView.swift
@@ -4,14 +4,35 @@ import SwiftUI
 
 struct CalendarSlimView: View {
 
+  private struct CalendarDay: Identifiable {
+    let weekday: WeekDay
+    let desc: String
+    let calendar: BangumiCalendar
+
+    var id: WeekDay {
+      weekday
+    }
+
+    var count: Int {
+      calendar.items.count
+    }
+
+    var watchers: Int {
+      calendar.items.reduce(0) { $0 + $1.watchers }
+    }
+  }
+
+  @Environment(\.scenePhase) private var scenePhase
+
+  @State private var currentDate = Calendar.current.startOfDay(for: Date())
   @State private var refreshed: Bool = false
 
   @Query(sort: \BangumiCalendar.weekday)
   private var calendars: [BangumiCalendar]
 
-  var dates: [(weekday: WeekDay, desc: String, date: Date, calendar: BangumiCalendar, count: Int, watchers: Int)] {
-    let today = Date()
-    let tomorrow = today.addingTimeInterval(86400)
+  private var dates: [CalendarDay] {
+    let today = currentDate
+    let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: today) ?? today
 
     let todayCalendar =
       calendars.first { $0.weekday == WeekDay(date: today).rawValue }
@@ -21,16 +42,17 @@ struct CalendarSlimView: View {
       ?? BangumiCalendar(weekday: WeekDay(date: tomorrow).rawValue, items: [])
 
     let result = [
-      (weekday: WeekDay(date: today), desc: "今天", date: today,
-       calendar: todayCalendar,
-       count: todayCalendar.items.count,
-       watchers: todayCalendar.items.reduce(0) { $0 + $1.watchers }),
-      (weekday: WeekDay(date: tomorrow), desc: "明天", date: tomorrow,
-       calendar: tomorrowCalendar,
-       count: tomorrowCalendar.items.count,
-       watchers: tomorrowCalendar.items.reduce(0) { $0 + $1.watchers }),
+      CalendarDay(weekday: WeekDay(date: today), desc: "今天", calendar: todayCalendar),
+      CalendarDay(weekday: WeekDay(date: tomorrow), desc: "明天", calendar: tomorrowCalendar),
     ]
     return result
+  }
+
+  func updateCurrentDate() {
+    let today = Calendar.current.startOfDay(for: Date())
+    if currentDate != today {
+      currentDate = today
+    }
   }
 
   func refreshCalendar() async {
@@ -52,13 +74,13 @@ struct CalendarSlimView: View {
       } else {
         VStack(alignment: .leading, spacing: 8) {
           HStack(alignment: .bottom) {
-            Text("每日放送: \(Date().formatted(date: .long, time: .omitted))")
+            Text("每日放送: \(currentDate.formatted(date: .long, time: .omitted))")
             Spacer()
             NavigationLink(value: NavDestination.calendar) {
               Text("更多 »").font(.caption)
             }.buttonStyle(.navigation)
           }
-          ForEach(dates, id: \.weekday) { item in
+          ForEach(dates) { item in
             VStack(alignment: .leading, spacing: 6) {
               HStack(spacing: 4) {
                 Text(item.desc)
@@ -83,7 +105,19 @@ struct CalendarSlimView: View {
           Divider()
         }
       }
-    }.padding(.horizontal, 8)
+    }
+    .padding(.horizontal, 8)
+    .onAppear {
+      updateCurrentDate()
+    }
+    .onChange(of: scenePhase) {
+      if scenePhase == .active {
+        updateCurrentDate()
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+      updateCurrentDate()
+    }
   }
 }
 

--- a/App/Views/Discover/CalendarView.swift
+++ b/App/Views/Discover/CalendarView.swift
@@ -65,19 +65,18 @@ enum WeekDay: Int, CaseIterable {
 
 struct CalendarView: View {
 
+  @Environment(\.scenePhase) private var scenePhase
+
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
+  @State private var currentDate = Calendar.current.startOfDay(for: Date())
   @State private var refreshed: Bool = false
 
   @Query(sort: \BangumiCalendar.weekday)
   private var calendars: [BangumiCalendar]
 
-  var today: Date {
-    Date()
-  }
-
   var sortedCalendars: [BangumiCalendar] {
-    let todayWeekday = WeekDay(date: today).rawValue
+    let todayWeekday = WeekDay(date: currentDate).rawValue
     let sorted = calendars.sorted { $0.weekday < $1.weekday }
     guard let pivot = sorted.firstIndex(where: { $0.weekday >= todayWeekday }) else {
       return sorted
@@ -97,6 +96,13 @@ struct CalendarView: View {
     sortedCalendars.first?.items.reduce(0) { $0 + $1.watchers } ?? 0
   }
 
+  func updateCurrentDate() {
+    let today = Calendar.current.startOfDay(for: Date())
+    if currentDate != today {
+      currentDate = today
+    }
+  }
+
   func refreshCalendar() async {
     if refreshed { return }
     refreshed = true
@@ -108,38 +114,51 @@ struct CalendarView: View {
   }
 
   var body: some View {
-    if calendars.isEmpty {
-      ProgressView().task {
-        await refreshCalendar()
-      }
-    } else {
-      ScrollView {
-        VStack {
-          Text("每日放送")
-            .font(.title)
-            .padding(.top, 10)
+    Group {
+      if calendars.isEmpty {
+        ProgressView().task {
+          await refreshCalendar()
+        }
+      } else {
+        ScrollView {
           VStack {
-            Text("\(today.formatted(date: .complete, time: .omitted))")
-            Text("本季度共 \(total) 部番组，今日上映 \(todayTotal) 部。")
-            Text("共 \(todayWatchers) 人收看今日番组。")
-          }
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-        }.padding(.horizontal, 8)
-        LazyVStack {
-          ForEach(sortedCalendars) { calendar in
-            CalendarWeekdayView(calendar: calendar)
-              .padding(.vertical, 10)
-          }
-        }.padding(.horizontal, 8)
+            Text("每日放送")
+              .font(.title)
+              .padding(.top, 10)
+            VStack {
+              Text("\(currentDate.formatted(date: .complete, time: .omitted))")
+              Text("本季度共 \(total) 部番组，今日上映 \(todayTotal) 部。")
+              Text("共 \(todayWatchers) 人收看今日番组。")
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+          }.padding(.horizontal, 8)
+          LazyVStack {
+            ForEach(sortedCalendars) { calendar in
+              CalendarWeekdayView(calendar: calendar)
+                .padding(.vertical, 10)
+            }
+          }.padding(.horizontal, 8)
+        }
+        .navigationTitle("每日放送")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+          refreshed = false
+          UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+          await refreshCalendar()
+        }
       }
-      .navigationTitle("每日放送")
-      .navigationBarTitleDisplayMode(.inline)
-      .refreshable {
-        refreshed = false
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-        await refreshCalendar()
+    }
+    .onAppear {
+      updateCurrentDate()
+    }
+    .onChange(of: scenePhase) {
+      if scenePhase == .active {
+        updateCurrentDate()
       }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
+      updateCurrentDate()
     }
   }
 }


### PR DESCRIPTION
## Problem

The discover calendar can stay alive across midnight without any observable state change. Opening it afterward may still show yesterday/today instead of today/tomorrow, and the full calendar can retain the previous day's ordering.

## Approach

Track the current calendar day as view state and update it when the view appears, the app becomes active, or `NSCalendarDayChanged` is posted. Calculate tomorrow with `Calendar` arithmetic and use a dedicated value type for the slim calendar entries.

## Validation

- [x] `swift-format lint App/Views/Discover/CalendarSlimView.swift App/Views/Discover/CalendarView.swift`
- [x] `make build-ci`
