### PR TITLE
fix: reduce search focus hangs

### DIFF
--- a/App/Helpers/View+SearchInputTraits.swift
+++ b/App/Helpers/View+SearchInputTraits.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+extension View {
+  func searchInputTraits() -> some View {
+    self
+      .autocorrectionDisabled()
+      .textInputAutocapitalization(.never)
+      .submitLabel(.search)
+  }
+}

--- a/App/Views/Discover/ChiiDiscoverView.swift
+++ b/App/Views/Discover/ChiiDiscoverView.swift
@@ -18,15 +18,15 @@ struct ChiiDiscoverView: View {
   var body: some View {
     GeometryReader { geometry in
       VStack {
-        if searching {
-          SearchView(text: $query, searching: $searching, remote: $remote)
-        } else {
+        if query.isEmpty {
           ScrollView {
             VStack {
               CalendarSlimView()
               TrendingSubjectView(width: geometry.size.width)
             }
           }
+        } else {
+          SearchView(text: $query, remote: $remote)
         }
       }
     }
@@ -40,6 +40,7 @@ struct ChiiDiscoverView: View {
       placement: .navigationBarDrawer(displayMode: .always),
       prompt: "搜索条目，角色，人物"
     )
+    .searchInputTraits()
     .onChange(of: query) {
       remote = false
     }

--- a/App/Views/Discover/Search/SearchCharacterPickerView.swift
+++ b/App/Views/Discover/Search/SearchCharacterPickerView.swift
@@ -31,6 +31,7 @@ struct SearchCharacterPickerView: View {
       .navigationTitle("搜索角色")
       .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索角色")
+      .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
       .onSubmit(of: .search) {
         remote = true

--- a/App/Views/Discover/Search/SearchPersonPickerView.swift
+++ b/App/Views/Discover/Search/SearchPersonPickerView.swift
@@ -31,6 +31,7 @@ struct SearchPersonPickerView: View {
       .navigationTitle("搜索人物")
       .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索人物")
+      .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
       .onSubmit(of: .search) {
         remote = true

--- a/App/Views/Discover/Search/SearchSubjectPickerView.swift
+++ b/App/Views/Discover/Search/SearchSubjectPickerView.swift
@@ -48,6 +48,7 @@ struct SearchSubjectPickerView: View {
       .navigationTitle("搜索条目")
       .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索条目")
+      .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
       .onSubmit(of: .search) {
         remote = true

--- a/App/Views/Discover/Search/SearchView.swift
+++ b/App/Views/Discover/Search/SearchView.swift
@@ -10,7 +10,6 @@ enum SearchType {
 
 struct SearchView: View {
   @Binding var text: String
-  @Binding var searching: Bool
   @Binding var remote: Bool
 
   @State private var searchType: SearchType = .subject

--- a/App/Views/Progress/ChiiProgressView.swift
+++ b/App/Views/Progress/ChiiProgressView.swift
@@ -514,11 +514,12 @@ struct ChiiProgressView: View {
         placement: .navigationBarDrawer(displayMode: .always),
         prompt: "搜索正在观看的条目"
       )
+      .searchInputTraits()
       .navigationTitle("进度管理")
       .navigationBarTitleDisplayMode(.inline)
       .toolbar { progressToolbar }
       .onChange(of: progressTab) { Task { await reloadProgressPages(animate: true) } }
-      .onChange(of: search) { Task { await reloadProgressPages() } }
+      .onChange(of: search) { Task { await reloadProgressPages(animate: true) } }
       .onChange(of: progressSortMode) { Task { await reloadProgressPages(animate: true) } }
       .onChange(of: progressViewMode) { Task { await reloadProgressPages(animate: true) } }
       .onReceive(


### PR DESCRIPTION
## Problem

Opening SwiftUI search fields can trigger a short main-thread hang while UIKit prepares the keyboard, input assistant, AutoFill, and pasteboard support. The captured hang report pointed at the search field focus path rather than app data loading.

## Approach

Apply shared search input traits to search fields so they opt out of autocorrection and capitalization work, and avoid mounting the Discover search result view until there is actual query text. Progress search reloads continue to animate when the query changes.

## Validation

- [x] `git diff --check`
- [x] `make build`
