### PR TITLE
perf: reduce list render cost

### DIFF
--- a/App/Client/DisplayDTO.swift
+++ b/App/Client/DisplayDTO.swift
@@ -57,6 +57,15 @@ struct DraftDTO: Identifiable, Hashable {
   var updatedAt: Int
 }
 
+struct SubjectListItemDTO: Codable, Identifiable, Sendable {
+  var subject: SlimSubjectDTO
+  var collectionType: CollectionType
+
+  var id: Int {
+    subject.id
+  }
+}
+
 struct ProgressSubjectDTO: Codable, Identifiable, Sendable {
   var subject: SubjectDTO
   var episodes: [EpisodeDTO]

--- a/App/Components/PageView.swift
+++ b/App/Components/PageView.swift
@@ -21,7 +21,7 @@ extension Array where Element: Identifiable {
 /// A view that loads data continuously.
 ///
 struct PageView<T, C>: View
-where C: View, T: Identifiable & Hashable & Codable & Sendable {
+where C: View, T: Identifiable & Codable & Sendable {
   typealias Item = T
   typealias Content = C
 
@@ -44,11 +44,8 @@ where C: View, T: Identifiable & Hashable & Codable & Sendable {
       defer { loading = false }
       let result = await loadPage(currentOffset: 0)
       if let newData = result {
-        let updatedItems = [Item]().mergedById(with: newData)
-        if items != updatedItems {
-          withAnimation {
-            items = updatedItems
-          }
+        withAnimation {
+          items = [Item]().mergedById(with: newData)
         }
       }
     }
@@ -61,10 +58,7 @@ where C: View, T: Identifiable & Hashable & Codable & Sendable {
     defer { loading = false }
     let result = await loadPage(currentOffset: offset)
     if let newData = result {
-      let updatedItems = items.mergedById(with: newData)
-      if items != updatedItems {
-        items = updatedItems
-      }
+      items = items.mergedById(with: newData)
     }
   }
 
@@ -142,7 +136,7 @@ where C: View, T: Identifiable & Hashable & Codable & Sendable {
 }
 
 struct SimplePageView<T, C>: View
-where C: View, T: Identifiable & Hashable & Codable & Sendable {
+where C: View, T: Identifiable & Codable & Sendable {
   typealias Item = T
   typealias Content = C
 
@@ -163,11 +157,8 @@ where C: View, T: Identifiable & Hashable & Codable & Sendable {
       defer { loading = false }
       let result = await loadPage(currentPage: 1)
       if let newData = result {
-        let updatedItems = [Item]().mergedById(with: newData)
-        if items != updatedItems {
-          withAnimation {
-            items = updatedItems
-          }
+        withAnimation {
+          items = [Item]().mergedById(with: newData)
         }
       }
     }
@@ -180,10 +171,7 @@ where C: View, T: Identifiable & Hashable & Codable & Sendable {
     defer { loading = false }
     let result = await loadPage(currentPage: page)
     if let newData = result {
-      let updatedItems = items.mergedById(with: newData)
-      if items != updatedItems {
-        items = updatedItems
-      }
+      items = items.mergedById(with: newData)
     }
   }
 

--- a/App/Database/Operator.swift
+++ b/App/Database/Operator.swift
@@ -246,6 +246,16 @@ extension DatabaseOperator {
     return subjects.reduce(into: [:]) { $0[$1.subjectId] = $1.ctypeEnum }
   }
 
+  public func makeSubjectListItems(_ subjects: [SlimSubjectDTO]) throws -> [SubjectListItemDTO] {
+    let collectionTypes = try getCollectionTypes(subjectIds: subjects.map(\.id))
+    return subjects.map { subject in
+      SubjectListItemDTO(
+        subject: subject,
+        collectionType: collectionTypes[subject.id] ?? .none
+      )
+    }
+  }
+
   public func fetchLocalSubjects(
     search: String,
     subjectType: SubjectType,

--- a/App/Helpers/Extension.swift
+++ b/App/Helpers/Extension.swift
@@ -63,7 +63,22 @@ extension Array: @retroactive RawRepresentable where Element: Codable {
   }
 }
 
+struct IndexedIdentifiableItem<Item: Identifiable>: Identifiable {
+  let index: Int
+  let item: Item
+
+  var id: Item.ID {
+    item.id
+  }
+}
+
 extension Array where Element: Identifiable {
+  func indexedById() -> [IndexedIdentifiableItem<Element>] {
+    enumerated().map { index, item in
+      IndexedIdentifiableItem(index: index, item: item)
+    }
+  }
+
   func mergedById(with newData: [Element]) -> [Element] {
     if newData.isEmpty {
       return self

--- a/App/Views/Discover/Search/SearchSubjectPickerView.swift
+++ b/App/Views/Discover/Search/SearchSubjectPickerView.swift
@@ -81,7 +81,7 @@ struct SearchSubjectPickerRemoteView: View {
   @Environment(\.dismiss) var dismiss
   @State private var reloader = false
 
-  private func fetch(limit: Int, offset: Int) async -> PagedDTO<SlimSubjectDTO>? {
+  private func fetch(limit: Int, offset: Int) async -> PagedDTO<SubjectListItemDTO>? {
     do {
       guard let db = await AppContext.shared.databaseIfAvailable() else {
         throw ChiiError.uninitialized
@@ -92,7 +92,7 @@ struct SearchSubjectPickerRemoteView: View {
         try await db.saveSubject(item)
       }
       try await db.commit()
-      return resp
+      return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)
     }
@@ -100,8 +100,11 @@ struct SearchSubjectPickerRemoteView: View {
   }
 
   var body: some View {
-    PageView<SlimSubjectDTO, _>(reloader: reloader, nextPageFunc: fetch) { item in
-      SearchSubjectPickerItemView(subjectId: item.id) { selectedId in
+    PageView<SubjectListItemDTO, _>(reloader: reloader, nextPageFunc: fetch) { item in
+      SearchSubjectPickerItemView(
+        subject: item.subject,
+        collectionType: item.collectionType
+      ) { selectedId in
         onSelect(selectedId)
         dismiss()
       }
@@ -149,9 +152,31 @@ struct SearchSubjectPickerLocalView: View {
 
 struct SearchSubjectPickerItemView: View {
   let subjectId: Int
+  let slimSubject: SlimSubjectDTO?
+  let loadSubjectOnAppear: Bool
   let onSelect: (Int) -> Void
 
   @State private var subject: SubjectDTO?
+  @State private var collectionType: CollectionType = .none
+
+  init(subjectId: Int, onSelect: @escaping (Int) -> Void) {
+    self.subjectId = subjectId
+    self.slimSubject = nil
+    self.loadSubjectOnAppear = true
+    self.onSelect = onSelect
+  }
+
+  init(
+    subject: SlimSubjectDTO,
+    collectionType: CollectionType,
+    onSelect: @escaping (Int) -> Void
+  ) {
+    self.subjectId = subject.id
+    self.slimSubject = subject
+    self.loadSubjectOnAppear = false
+    self.onSelect = onSelect
+    self._collectionType = State(initialValue: collectionType)
+  }
 
   private func load() async {
     do {
@@ -166,13 +191,17 @@ struct SearchSubjectPickerItemView: View {
     CardView {
       if let subject = subject {
         SubjectLargeRowView(subject: subject)
+      } else if let slimSubject {
+        SubjectSlimRowView(subject: slimSubject, collectionType: collectionType)
       }
     }
     .onTapGesture {
       onSelect(subjectId)
     }
     .task(id: subjectId) {
-      await load()
+      if loadSubjectOnAppear {
+        await load()
+      }
     }
   }
 }

--- a/App/Views/Discover/Search/SearchSubjectPickerView.swift
+++ b/App/Views/Discover/Search/SearchSubjectPickerView.swift
@@ -151,57 +151,26 @@ struct SearchSubjectPickerLocalView: View {
 }
 
 struct SearchSubjectPickerItemView: View {
-  let subjectId: Int
-  let slimSubject: SlimSubjectDTO?
-  let loadSubjectOnAppear: Bool
+  let subject: SlimSubjectDTO
+  let collectionType: CollectionType
   let onSelect: (Int) -> Void
-
-  @State private var subject: SubjectDTO?
-  @State private var collectionType: CollectionType = .none
-
-  init(subjectId: Int, onSelect: @escaping (Int) -> Void) {
-    self.subjectId = subjectId
-    self.slimSubject = nil
-    self.loadSubjectOnAppear = true
-    self.onSelect = onSelect
-  }
 
   init(
     subject: SlimSubjectDTO,
     collectionType: CollectionType,
     onSelect: @escaping (Int) -> Void
   ) {
-    self.subjectId = subject.id
-    self.slimSubject = subject
-    self.loadSubjectOnAppear = false
+    self.subject = subject
+    self.collectionType = collectionType
     self.onSelect = onSelect
-    self._collectionType = State(initialValue: collectionType)
-  }
-
-  private func load() async {
-    do {
-      let db = try await AppContext.shared.getDB()
-      subject = try await db.getSubjectDTO(subjectId)
-    } catch {
-      Notifier.shared.alert(error: error)
-    }
   }
 
   var body: some View {
     CardView {
-      if let subject = subject {
-        SubjectLargeRowView(subject: subject)
-      } else if let slimSubject {
-        SubjectSlimRowView(subject: slimSubject, collectionType: collectionType)
-      }
+      SubjectSlimRowView(subject: subject, collectionType: collectionType)
     }
     .onTapGesture {
-      onSelect(subjectId)
-    }
-    .task(id: subjectId) {
-      if loadSubjectOnAppear {
-        await load()
-      }
+      onSelect(subject.id)
     }
   }
 }

--- a/App/Views/Discover/Search/SearchSubjectView.swift
+++ b/App/Views/Discover/Search/SearchSubjectView.swift
@@ -27,7 +27,7 @@ struct SearchSubjectView: View {
 
   var body: some View {
     PageView<SubjectListItemDTO, _>(reloader: reloader, nextPageFunc: fetch) { item in
-      SubjectItemView(subject: item.subject, collectionType: item.collectionType)
+      SubjectSlimItemView(subject: item.subject, collectionType: item.collectionType)
     }
     .onChange(of: subjectType) { _, _ in
       reloader.toggle()

--- a/App/Views/Discover/Search/SearchSubjectView.swift
+++ b/App/Views/Discover/Search/SearchSubjectView.swift
@@ -7,7 +7,7 @@ struct SearchSubjectView: View {
 
   @State private var reloader = false
 
-  func fetch(limit: Int, offset: Int) async -> PagedDTO<SlimSubjectDTO>? {
+  func fetch(limit: Int, offset: Int) async -> PagedDTO<SubjectListItemDTO>? {
     do {
       guard let db = await AppContext.shared.databaseIfAvailable() else {
         throw ChiiError.uninitialized
@@ -18,7 +18,7 @@ struct SearchSubjectView: View {
         try await db.saveSubject(item)
       }
       try await db.commit()
-      return resp
+      return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)
     }
@@ -26,8 +26,8 @@ struct SearchSubjectView: View {
   }
 
   var body: some View {
-    PageView<SlimSubjectDTO, _>(reloader: reloader, nextPageFunc: fetch) { item in
-      SubjectItemView(subjectId: item.id)
+    PageView<SubjectListItemDTO, _>(reloader: reloader, nextPageFunc: fetch) { item in
+      SubjectItemView(subject: item.subject, collectionType: item.collectionType)
     }
     .onChange(of: subjectType) { _, _ in
       reloader.toggle()

--- a/App/Views/Episode/EpisodeDiscView.swift
+++ b/App/Views/Episode/EpisodeDiscView.swift
@@ -73,11 +73,10 @@ struct EpisodeDiscView: View {
           Divider()
         }
       }
-    }.animation(.default, value: episodes)
-      .task {
-        await loadCached()
-        refresh()
-      }
+    }.task {
+      await loadCached()
+      refresh()
+    }
   }
 }
 

--- a/App/Views/Episode/EpisodeGridView.swift
+++ b/App/Views/Episode/EpisodeGridView.swift
@@ -94,8 +94,6 @@ struct EpisodeGridView: View {
         Spacer()
       }
     )
-    .animation(.default, value: episodeMains)
-    .animation(.default, value: episodeSps)
     .task {
       await loadCached()
       refresh()

--- a/App/Views/Episode/EpisodeListView.swift
+++ b/App/Views/Episode/EpisodeListView.swift
@@ -110,7 +110,6 @@ struct EpisodeListDetailView: View {
         }
       }.padding(.horizontal, 8)
     }
-    .animation(.default, value: episodes)
     .task(id: "\(subjectId)-\(sortDesc)-\(main)-\(filterCollection)-\(reloadToken)") {
       await load()
     }

--- a/App/Views/Profile/CollectionListView.swift
+++ b/App/Views/Profile/CollectionListView.swift
@@ -108,7 +108,6 @@ struct CollectionListView: View {
           .animation(.easeInOut, value: collectionType)
         }
         .animation(.default, value: counts)
-        .animation(.default, value: subjects)
       }
     }
     .navigationTitle("我的\(subjectType.description)")

--- a/App/Views/Profile/CollectionSubjectTypeView.swift
+++ b/App/Views/Profile/CollectionSubjectTypeView.swift
@@ -61,6 +61,6 @@ struct CollectionSubjectTypeView: View {
         }
       }
       .scrollClipDisabled()
-    }.animation(.default, value: subjects)
+    }
   }
 }

--- a/App/Views/Rakuen/RakuenGroupTopicView.swift
+++ b/App/Views/Rakuen/RakuenGroupTopicView.swift
@@ -122,11 +122,8 @@ struct CachedGroupTopicListView: View {
 
     do {
       let resp = try await TopicService.getRecentGroupTopics(mode: mode, limit: 20, offset: 0)
-      let updatedItems = [GroupTopicDTO]().mergedById(with: resp.data)
-      if items != updatedItems {
-        withAnimation {
-          items = updatedItems
-        }
+      withAnimation {
+        items = [GroupTopicDTO]().mergedById(with: resp.data)
       }
       offset = 20
       exhausted = resp.data.count == 0 || offset >= resp.total
@@ -149,12 +146,7 @@ struct CachedGroupTopicListView: View {
 
     do {
       let resp = try await TopicService.getRecentGroupTopics(mode: mode, limit: 20, offset: offset)
-      let updatedItems = items.mergedById(with: resp.data)
-      if items != updatedItems {
-        withAnimation {
-          items = updatedItems
-        }
-      }
+      items = items.mergedById(with: resp.data)
       offset += 20
       if resp.data.count == 0 || offset >= resp.total {
         exhausted = true

--- a/App/Views/Rakuen/RakuenSubjectTopicView.swift
+++ b/App/Views/Rakuen/RakuenSubjectTopicView.swift
@@ -138,11 +138,8 @@ struct CachedSubjectTopicListView: View {
         resp = try await TopicService.getRecentSubjectTopics(limit: 20, offset: 0)
       }
       if let resp = resp {
-        let updatedItems = [SubjectTopicDTO]().mergedById(with: resp.data)
-        if items != updatedItems {
-          withAnimation {
-            items = updatedItems
-          }
+        withAnimation {
+          items = [SubjectTopicDTO]().mergedById(with: resp.data)
         }
         offset = 20
         exhausted = resp.data.count == 0 || offset >= resp.total
@@ -173,12 +170,7 @@ struct CachedSubjectTopicListView: View {
         resp = try await TopicService.getRecentSubjectTopics(limit: 20, offset: offset)
       }
       if let resp = resp {
-        let updatedItems = items.mergedById(with: resp.data)
-        if items != updatedItems {
-          withAnimation {
-            items = updatedItems
-          }
-        }
+        items = items.mergedById(with: resp.data)
         offset += 20
         if resp.data.count == 0 || offset >= resp.total {
           exhausted = true

--- a/App/Views/Subject/SubjectBrowsingView.swift
+++ b/App/Views/Subject/SubjectBrowsingView.swift
@@ -123,7 +123,7 @@ struct SubjectBrowsingView: View {
         browseHeader
 
         SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { item in
-          SubjectItemView(subject: item.subject, collectionType: item.collectionType)
+          SubjectSlimItemView(subject: item.subject, collectionType: item.collectionType)
         }
         .zIndex(0)
 
@@ -610,7 +610,7 @@ struct SubjectTagBrowsingView: View {
         Divider()
 
         SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { item in
-          SubjectItemView(subject: item.subject, collectionType: item.collectionType)
+          SubjectSlimItemView(subject: item.subject, collectionType: item.collectionType)
         }
       }.padding(.horizontal, 8)
     }

--- a/App/Views/Subject/SubjectBrowsingView.swift
+++ b/App/Views/Subject/SubjectBrowsingView.swift
@@ -37,7 +37,7 @@ struct SubjectBrowsingView: View {
     return Array(categories.values.sorted { $0.id < $1.id })
   }
 
-  func fetchPage(page: Int) async -> PagedDTO<SlimSubjectDTO>? {
+  func fetchPage(page: Int) async -> PagedDTO<SubjectListItemDTO>? {
     do {
       guard let db = await AppContext.shared.databaseIfAvailable() else {
         throw ChiiError.uninitialized
@@ -48,7 +48,7 @@ struct SubjectBrowsingView: View {
         try await db.saveSubject(item)
       }
       try await db.commit()
-      return resp
+      return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)
     }
@@ -122,8 +122,8 @@ struct SubjectBrowsingView: View {
       LazyVStack(alignment: .leading, spacing: 8) {
         browseHeader
 
-        SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { subject in
-          SubjectItemView(subjectId: subject.id)
+        SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { item in
+          SubjectItemView(subject: item.subject, collectionType: item.collectionType)
         }
         .zIndex(0)
 
@@ -549,7 +549,7 @@ struct SubjectTagBrowsingView: View {
     return "\(prefix): \(tag)"
   }
 
-  func fetchPage(page: Int) async -> PagedDTO<SlimSubjectDTO>? {
+  func fetchPage(page: Int) async -> PagedDTO<SubjectListItemDTO>? {
     do {
       guard let db = await AppContext.shared.databaseIfAvailable() else {
         throw ChiiError.uninitialized
@@ -563,7 +563,7 @@ struct SubjectTagBrowsingView: View {
         try await db.saveSubject(item)
       }
       try await db.commit()
-      return resp
+      return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)
     }
@@ -609,8 +609,8 @@ struct SubjectTagBrowsingView: View {
 
         Divider()
 
-        SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { subject in
-          SubjectItemView(subjectId: subject.id)
+        SimplePageView(reloader: reloader, nextPageFunc: fetchPage) { item in
+          SubjectItemView(subject: item.subject, collectionType: item.collectionType)
         }
       }.padding(.horizontal, 8)
     }

--- a/App/Views/Subject/SubjectLargeRowView.swift
+++ b/App/Views/Subject/SubjectLargeRowView.swift
@@ -102,10 +102,112 @@ struct SubjectLargeRowView: View {
   }
 }
 
+struct SubjectSlimRowView: View {
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
+
+  let subject: SlimSubjectDTO
+  let collectionType: CollectionType
+
+  var body: some View {
+    HStack {
+      ImageView(img: subject.images?.resize(.r200))
+        .imageCollectionStatus(ctype: collectionType)
+        .imageStyle(width: 90, height: subject.type.coverHeight(for: 90))
+        .imageType(.subject)
+        .imageNSFW(subject.nsfw)
+        .imageNavLink(subject.link)
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 4) {
+          VStack(alignment: .leading) {
+            HStack(spacing: 4) {
+              if subject.type != .none {
+                Image(systemName: subject.type.icon)
+                  .foregroundStyle(.secondary)
+                  .font(.footnote)
+              }
+              Text(subject.title(with: titlePreference).withLink(subject.link))
+                .font(.headline)
+                .lineLimit(1)
+            }
+          }
+          Spacer(minLength: 0)
+          if let rating = subject.rating, rating.rank > 0 {
+            Label(String(rating.rank), systemImage: "chart.bar.xaxis")
+              .foregroundStyle(.accent)
+              .font(.footnote)
+          }
+        }
+
+        if let subtitle = subject.subtitle(with: titlePreference) {
+          Text(subtitle)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+
+        if let info = subject.info, !info.isEmpty {
+          Text(info)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+        }
+
+        HStack(spacing: 4) {
+          if subject.type != .none {
+            BorderView {
+              Text(subject.type.description).lineLimit(1)
+            }
+          }
+        }
+        .foregroundStyle(.secondary)
+        .font(.caption)
+
+        if let rating = subject.rating {
+          HStack {
+            if rating.total > 10, rating.score > 0 {
+              StarsView(score: rating.score, size: 12)
+              Text("\(rating.score.rateDisplay)")
+                .font(.callout)
+                .foregroundStyle(.orange)
+              Text("(\(rating.total)人评分)")
+                .foregroundStyle(.secondary)
+            } else {
+              StarsView(score: 0, size: 12)
+              Text("(少于10人评分)")
+                .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+          }
+          .font(.footnote)
+        }
+      }.padding(.leading, 2)
+    }
+    .frame(minHeight: subject.type.coverHeight(for: 90))
+    .padding(2)
+    .clipShape(RoundedRectangle(cornerRadius: 10))
+  }
+}
+
 struct SubjectItemView: View {
   let subjectId: Int
+  let slimSubject: SlimSubjectDTO?
+  let loadSubjectOnAppear: Bool
 
   @State private var subject: SubjectDTO?
+  @State private var collectionType: CollectionType = .none
+
+  init(subjectId: Int) {
+    self.subjectId = subjectId
+    self.slimSubject = nil
+    self.loadSubjectOnAppear = true
+  }
+
+  init(subject: SlimSubjectDTO, collectionType: CollectionType) {
+    self.subjectId = subject.id
+    self.slimSubject = subject
+    self.loadSubjectOnAppear = false
+    self._collectionType = State(initialValue: collectionType)
+  }
 
   private func load() async {
     do {
@@ -113,6 +215,15 @@ struct SubjectItemView: View {
       subject = try await db.getSubjectDTO(subjectId)
     } catch {
       Logger.app.error("Failed to load subject item: \(error)")
+    }
+  }
+
+  private func loadCollectionType() async {
+    do {
+      let db = try await AppContext.shared.getDB()
+      collectionType = try await db.getCollectionTypes(subjectIds: [subjectId])[subjectId] ?? .none
+    } catch {
+      Logger.app.error("Failed to load subject collection type: \(error)")
     }
   }
 
@@ -126,10 +237,20 @@ struct SubjectItemView: View {
             collectionType: subject.ctypeEnum,
             reload: load
           )
+      } else if let slimSubject {
+        SubjectSlimRowView(subject: slimSubject, collectionType: collectionType)
+          .subjectCollectionStatusOverlay(
+            subjectId: slimSubject.id,
+            subjectType: slimSubject.type,
+            collectionType: collectionType,
+            reload: loadCollectionType
+          )
       }
     }
     .task(id: subjectId) {
-      await load()
+      if loadSubjectOnAppear {
+        await load()
+      }
     }
   }
 }

--- a/App/Views/Subject/SubjectLargeRowView.swift
+++ b/App/Views/Subject/SubjectLargeRowView.swift
@@ -190,24 +190,8 @@ struct SubjectSlimRowView: View {
 
 struct SubjectItemView: View {
   let subjectId: Int
-  let slimSubject: SlimSubjectDTO?
-  let loadSubjectOnAppear: Bool
 
   @State private var subject: SubjectDTO?
-  @State private var collectionType: CollectionType = .none
-
-  init(subjectId: Int) {
-    self.subjectId = subjectId
-    self.slimSubject = nil
-    self.loadSubjectOnAppear = true
-  }
-
-  init(subject: SlimSubjectDTO, collectionType: CollectionType) {
-    self.subjectId = subject.id
-    self.slimSubject = subject
-    self.loadSubjectOnAppear = false
-    self._collectionType = State(initialValue: collectionType)
-  }
 
   private func load() async {
     do {
@@ -215,15 +199,6 @@ struct SubjectItemView: View {
       subject = try await db.getSubjectDTO(subjectId)
     } catch {
       Logger.app.error("Failed to load subject item: \(error)")
-    }
-  }
-
-  private func loadCollectionType() async {
-    do {
-      let db = try await AppContext.shared.getDB()
-      collectionType = try await db.getCollectionTypes(subjectIds: [subjectId])[subjectId] ?? .none
-    } catch {
-      Logger.app.error("Failed to load subject collection type: \(error)")
     }
   }
 
@@ -237,20 +212,47 @@ struct SubjectItemView: View {
             collectionType: subject.ctypeEnum,
             reload: load
           )
-      } else if let slimSubject {
-        SubjectSlimRowView(subject: slimSubject, collectionType: collectionType)
-          .subjectCollectionStatusOverlay(
-            subjectId: slimSubject.id,
-            subjectType: slimSubject.type,
-            collectionType: collectionType,
-            reload: loadCollectionType
-          )
       }
     }
     .task(id: subjectId) {
-      if loadSubjectOnAppear {
-        await load()
-      }
+      await load()
+    }
+  }
+}
+
+struct SubjectSlimItemView: View {
+  let subject: SlimSubjectDTO
+  let initialCollectionType: CollectionType
+
+  @State private var collectionType: CollectionType
+
+  init(subject: SlimSubjectDTO, collectionType: CollectionType) {
+    self.subject = subject
+    self.initialCollectionType = collectionType
+    self._collectionType = State(initialValue: collectionType)
+  }
+
+  private func loadCollectionType() async {
+    do {
+      let db = try await AppContext.shared.getDB()
+      collectionType = try await db.getCollectionTypes(subjectIds: [subject.id])[subject.id] ?? .none
+    } catch {
+      Logger.app.error("Failed to load subject collection type: \(error)")
+    }
+  }
+
+  var body: some View {
+    CardView {
+      SubjectSlimRowView(subject: subject, collectionType: collectionType)
+        .subjectCollectionStatusOverlay(
+          subjectId: subject.id,
+          subjectType: subject.type,
+          collectionType: collectionType,
+          reload: loadCollectionType
+        )
+    }
+    .onChange(of: initialCollectionType) { _, newValue in
+      collectionType = newValue
     }
   }
 }

--- a/App/Views/Timeline/TimelineListView.swift
+++ b/App/Views/Timeline/TimelineListView.swift
@@ -120,15 +120,15 @@ struct TimelineListView: View {
         }
       }.padding(8)
       LazyVStack(alignment: .leading) {
-        ForEach(Array(zip(items.indices, items)), id: \.1) { idx, item in
+        ForEach(items.indexedById()) { row in
           TimelineItemView(
-            item: item,
-            previousUID: idx == items.startIndex ? nil : items[idx - 1].user?.id
+            item: row.item,
+            previousUID: row.index == items.startIndex ? nil : items[row.index - 1].user?.id
           )
           .padding(.bottom, 8)
           .onAppear {
             Task {
-              await loadNextPage(item)
+              await loadNextPage(row.item)
             }
           }
         }
@@ -141,7 +141,6 @@ struct TimelineListView: View {
         }
       }.padding(.horizontal, 8)
     }
-    .animation(.default, value: items)
     .task {
       if items.count > 0 {
         return

--- a/App/Views/User/UserSubjectCollectionView.swift
+++ b/App/Views/User/UserSubjectCollectionView.swift
@@ -116,7 +116,6 @@ struct UserSubjectCollectionView: View {
       }
       .animation(.default, value: ctype)
       .animation(.default, value: refreshing)
-      .animation(.default, value: subjects)
     }
   }
 }

--- a/App/Views/User/UserTimelineView.swift
+++ b/App/Views/User/UserTimelineView.swift
@@ -70,13 +70,13 @@ struct UserTimelineView: View {
         .padding(.top, 8)
         .padding(.horizontal, 8)
       LazyVStack(alignment: .leading) {
-        ForEach(Array(zip(items.indices, items)), id: \.1) { idx, item in
+        ForEach(items.indexedById()) { row in
           TimelineItemView(
-            item: item,
-            previousUID: idx == items.startIndex ? nil : items[idx - 1].user?.id
+            item: row.item,
+            previousUID: row.index == items.startIndex ? nil : items[row.index - 1].user?.id
           ).onAppear {
             Task {
-              await loadNextPage(item)
+              await loadNextPage(row.item)
             }
           }
         }
@@ -91,7 +91,6 @@ struct UserTimelineView: View {
     }
     .navigationTitle(title)
     .navigationBarTitleDisplayMode(.inline)
-    .animation(.default, value: items)
     .task {
       if items.count > 0 {
         return


### PR DESCRIPTION
## Problem
Heavy SwiftUI lists still had a few expensive update patterns after the progress page work: generic pagination required `Hashable`, append paths compared whole DTO arrays, some scrolling lists animated every array mutation, and remote subject lists rendered by forcing each cell through a local full-subject fetch.

## Approach
Reduce diff and render cost on the hot paths without changing persistence schema or service boundaries. Pagination now depends only on stable IDs, heavy append paths avoid whole-array equality checks and broad animations, timeline identity uses item IDs, and remote subject rows render from a lightweight payload while collection status is still sourced from local persistence.

## Scope
- Relax `PageView` and `SimplePageView` item constraints and remove whole-array update guards.
- Remove broad array-driven animations from timeline, Rakuen cached topic lists, episode lists, and collection lists.
- Add `SubjectListItemDTO` and local collection-state wrapping for remote subject browsing/search results.
- Add a lightweight slim subject row for remote subject lists to avoid per-cell full subject loading on first render.

## Validation
- [x] `git diff --check`
- [x] `make build`
