### PR TITLE
ci: delay GitHub releases until next minor bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,13 @@ jobs:
     outputs:
       marketing_version: ${{ steps.version.outputs.marketing }}
       build_number: ${{ steps.version.outputs.build }}
+      base_marketing_version: ${{ steps.changed.outputs.base_marketing }}
+      base_build_number: ${{ steps.changed.outputs.base_build }}
       build_changed: ${{ steps.changed.outputs.build_changed }}
       marketing_changed: ${{ steps.changed.outputs.marketing_changed }}
+      create_release: ${{ steps.changed.outputs.create_release }}
+      release_version: ${{ steps.changed.outputs.release_version }}
+      release_sha: ${{ steps.changed.outputs.release_sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -58,6 +63,7 @@ jobs:
           FILE="Bangumi.xcodeproj/project.pbxproj"
           BASE="${{ github.event.before }}"
           HEAD="${{ github.sha }}"
+          HEAD_MARKETING="${{ steps.version.outputs.marketing }}"
 
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
             if git rev-parse "${HEAD}^" >/dev/null 2>&1; then
@@ -67,9 +73,38 @@ jobs:
             fi
           fi
 
+          read_project_value() {
+            local source="$1"
+            local key="$2"
+            if [ "$source" = "WORKTREE" ]; then
+              awk -v key="$key" '$0 ~ key " = " { sub(".*" key " = ", "", $0); sub(";.*", "", $0); gsub(/"/, "", $0); print $0; exit }' "$FILE"
+            else
+              git show "$source:$FILE" | awk -v key="$key" '$0 ~ key " = " { sub(".*" key " = ", "", $0); sub(";.*", "", $0); gsub(/"/, "", $0); print $0; exit }'
+            fi
+          }
+
+          parse_major_minor() {
+            local version="$1"
+            local prefix="$2"
+            if [[ "$version" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+              printf -v "${prefix}_MAJOR" "%s" "${BASH_REMATCH[1]}"
+              printf -v "${prefix}_MINOR" "%s" "${BASH_REMATCH[2]}"
+              return 0
+            fi
+            return 1
+          }
+
           BUILD_CHANGED=false
           MARKETING_CHANGED=false
+          CREATE_RELEASE=false
+          BASE_MARKETING=""
+          BASE_BUILD=""
+          RELEASE_VERSION=""
+          RELEASE_SHA=""
           if [ -n "$BASE" ] && git cat-file -e "$BASE"^{commit} 2>/dev/null; then
+            BASE_MARKETING="$(read_project_value "$BASE" MARKETING_VERSION)"
+            BASE_BUILD="$(read_project_value "$BASE" CURRENT_PROJECT_VERSION)"
+
             DIFF=$(git diff "$BASE" "$HEAD" -- "$FILE" || true)
             if echo "$DIFF" | grep -q 'CURRENT_PROJECT_VERSION'; then
               BUILD_CHANGED=true
@@ -77,18 +112,41 @@ jobs:
             if echo "$DIFF" | grep -q 'MARKETING_VERSION'; then
               MARKETING_CHANGED=true
             fi
+
+            if [ "$MARKETING_CHANGED" = true ] \
+              && parse_major_minor "$BASE_MARKETING" BASE_VERSION \
+              && parse_major_minor "$HEAD_MARKETING" HEAD_VERSION; then
+              if [ "$BASE_VERSION_MAJOR" -eq "$HEAD_VERSION_MAJOR" ] \
+                && [ "$HEAD_VERSION_MINOR" -eq $((BASE_VERSION_MINOR + 1)) ]; then
+                CREATE_RELEASE=true
+                RELEASE_VERSION="$BASE_MARKETING"
+                RELEASE_SHA="$BASE"
+              fi
+            fi
           else
             BUILD_CHANGED=true
             MARKETING_CHANGED=true
           fi
 
+          echo "Base MARKETING_VERSION: ${BASE_MARKETING:-unknown}"
+          echo "Base CURRENT_PROJECT_VERSION: ${BASE_BUILD:-unknown}"
+          echo "Create delayed release: $CREATE_RELEASE"
+          if [ "$CREATE_RELEASE" = true ]; then
+            echo "Release target: v$RELEASE_VERSION at $RELEASE_SHA"
+          fi
+
+          echo "base_marketing=$BASE_MARKETING" >> "$GITHUB_OUTPUT"
+          echo "base_build=$BASE_BUILD" >> "$GITHUB_OUTPUT"
           echo "build_changed=$BUILD_CHANGED" >> "$GITHUB_OUTPUT"
           echo "marketing_changed=$MARKETING_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "create_release=$CREATE_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
   release:
     runs-on: ubuntu-latest
     needs: detect
-    if: needs.detect.outputs.marketing_changed == 'true'
+    if: needs.detect.outputs.create_release == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -96,15 +154,16 @@ jobs:
       - name: Ensure GitHub release exists
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.detect.outputs.marketing_version }}
+          VERSION: ${{ needs.detect.outputs.release_version }}
+          TARGET_SHA: ${{ needs.detect.outputs.release_sha }}
         run: |
           set -euo pipefail
           TAG="v${VERSION}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists."
           else
-            echo "Creating release: $TAG"
-            gh release create "$TAG" --target "$GITHUB_SHA" --title "$TAG" --generate-notes
+            echo "Creating release: $TAG at $TARGET_SHA"
+            gh release create "$TAG" --target "$TARGET_SHA" --title "$TAG" --generate-notes
           fi
 
   upload:
@@ -180,17 +239,3 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         run: make release-ios
-
-      - name: Create artifact
-        if: needs.detect.outputs.marketing_changed == 'true'
-        run: make artifact-ios
-
-      - name: Upload artifact to GitHub Release
-        if: needs.detect.outputs.marketing_changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.detect.outputs.marketing_version }}
-        run: |
-          set -euo pipefail
-          TAG="v${VERSION}"
-          gh release upload "$TAG" artifacts/* --clobber

--- a/Bangumi.xcodeproj/project.pbxproj
+++ b/Bangumi.xcodeproj/project.pbxproj
@@ -300,7 +300,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 142;
+				CURRENT_PROJECT_VERSION = 143;
 				DEVELOPMENT_ASSET_PATHS = "\"App/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -318,7 +318,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.everpcpc.chobits;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -337,7 +337,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 142;
+				CURRENT_PROJECT_VERSION = 143;
 				DEVELOPMENT_ASSET_PATHS = "\"App/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = M777UHWZA4;
@@ -357,7 +357,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.13;
+				MARKETING_VERSION = 2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.everpcpc.chobits;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
## Summary

- Delay GitHub release creation until a same-major minor version bump, so `2.0 -> 2.1` creates `v2.0`.
- Keep App Store Connect uploads tied to build number changes, so `1.13 -> 2.0` still uploads the `2.0` build without creating a GitHub release.
- Remove IPA artifact upload from GitHub releases.
- Bump the app marketing version to `2.0` via `make major`.

## Behavior

- `1.13 -> 2.0`: uploads the `2.0` build, skips GitHub release creation.
- `2.0 -> 2.1`: uploads the `2.1` build and creates `v2.0` at the previous commit.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml"); puts "YAML OK"'`
- `git diff --check upstream/main...HEAD`
- Bash simulation for `1.13 -> 2.0` and `2.0 -> 2.1` release decisions
- `plutil -lint Bangumi.xcodeproj/project.pbxproj`
- `make build`
