### PR TITLE
refactor: remove no-op database commit

### DIFF
--- a/App/Client/CharacterRepository.swift
+++ b/App/Client/CharacterRepository.swift
@@ -27,7 +27,6 @@ enum CharacterRepository {
       throw ChiiError(message: "这是一个被合并的角色")
     }
     try await db.saveCharacter(item)
-    try await db.commit()
     if item.collectedAt != nil {
       await SearchIndexing.index([item.searchable()])
     }
@@ -50,7 +49,6 @@ enum CharacterRepository {
       relations: await relationsTask.value?.data,
       indexes: await indexesTask.value?.data
     )
-    try await db.commit()
   }
 
   static func collectCharacter(_ characterId: Int) async throws {
@@ -58,13 +56,11 @@ enum CharacterRepository {
     let db = try await AppContext.shared.getDB()
     let now = Int(Date().timeIntervalSince1970)
     try await db.updateCharacterCollection(characterId: characterId, collectedAt: now - 1)
-    try await db.commit()
   }
 
   static func uncollectCharacter(_ characterId: Int) async throws {
     try await CharacterService.uncollectCharacter(characterId)
     let db = try await AppContext.shared.getDB()
     try await db.updateCharacterCollection(characterId: characterId, collectedAt: 0)
-    try await db.commit()
   }
 }

--- a/App/Client/DiscoveryRepository.swift
+++ b/App/Client/DiscoveryRepository.swift
@@ -12,7 +12,6 @@ enum DiscoveryRepository {
       }
       try await db.saveCalendarItem(weekday: weekday, items: items)
     }
-    try await db.commit()
   }
 
   static func loadTrendingSubjects() async throws {
@@ -38,7 +37,6 @@ enum DiscoveryRepository {
       }
     }
     if saved {
-      try await db.commit()
     } else if let firstError {
       throw firstError
     }

--- a/App/Client/EpisodeRepository.swift
+++ b/App/Client/EpisodeRepository.swift
@@ -26,7 +26,6 @@ enum EpisodeRepository {
     }
     try await db.saveEpisodes(subjectId: subjectId, items: items)
     try await db.deleteEpisodesNotIn(subjectId: subjectId, episodeIds: episodeIds)
-    try await db.commit()
     await ProgressSubjectInvalidation.post(subjectId: subjectId)
   }
 
@@ -34,14 +33,12 @@ enum EpisodeRepository {
     let db = try await AppContext.shared.getDB()
     let item = try await EpisodeService.getEpisode(episodeId)
     try await db.saveEpisode(item)
-    try await db.commit()
     await ProgressSubjectInvalidation.post(subjectId: item.subjectID)
   }
 
   static func deleteEpisode(_ episodeId: Int) async throws {
     let db = try await AppContext.shared.getDB()
     try await db.deleteEpisode(episodeId)
-    try await db.commit()
   }
 
   static func updateEpisodeCollection(
@@ -51,7 +48,6 @@ enum EpisodeRepository {
     let db = try await AppContext.shared.getDB()
     let subjectId = try await db.updateEpisodeCollection(
       episodeId: episodeId, type: type, batch: batch)
-    try await db.commit()
     if let subjectId {
       await ProgressSubjectInvalidation.post(subjectId: subjectId)
     }

--- a/App/Client/GroupRepository.swift
+++ b/App/Client/GroupRepository.swift
@@ -23,7 +23,6 @@ enum GroupRepository {
     let db = try await AppContext.shared.getDB()
     let item = try await GroupService.getGroup(name)
     try await db.saveGroup(item)
-    try await db.commit()
   }
 
   static func loadGroupDetails(_ name: String) async throws {
@@ -43,6 +42,5 @@ enum GroupRepository {
       moderators: await moderatorsTask.value?.data,
       recentTopics: await topicsTask.value?.data
     )
-    try await db.commit()
   }
 }

--- a/App/Client/PersonRepository.swift
+++ b/App/Client/PersonRepository.swift
@@ -27,7 +27,6 @@ enum PersonRepository {
       throw ChiiError(message: "这是一个被合并的人物")
     }
     try await db.savePerson(item)
-    try await db.commit()
     if item.collectedAt != nil {
       await SearchIndexing.index([item.searchable()])
     }
@@ -54,7 +53,6 @@ enum PersonRepository {
       relations: await relationsTask.value?.data,
       indexes: await indexesTask.value?.data
     )
-    try await db.commit()
   }
 
   static func collectPerson(_ personId: Int) async throws {
@@ -62,13 +60,11 @@ enum PersonRepository {
     let db = try await AppContext.shared.getDB()
     let now = Int(Date().timeIntervalSince1970)
     try await db.updatePersonCollection(personId: personId, collectedAt: now - 1)
-    try await db.commit()
   }
 
   static func uncollectPerson(_ personId: Int) async throws {
     try await PersonService.uncollectPerson(personId)
     let db = try await AppContext.shared.getDB()
     try await db.updatePersonCollection(personId: personId, collectedAt: 0)
-    try await db.commit()
   }
 }

--- a/App/Client/SubjectRepository.swift
+++ b/App/Client/SubjectRepository.swift
@@ -29,7 +29,6 @@ enum SubjectRepository {
     }
 
     try await db.saveSubject(item)
-    try await db.commit()
     if item.interest != nil {
       await SearchIndexing.index([item.searchable()])
     }
@@ -127,7 +126,6 @@ enum SubjectRepository {
       comments: await commentsTask?.value?.data,
       indexes: await indexesTask.value?.data
     )
-    try await db.commit()
   }
 
   static func loadSubjectPositions(_ subjectId: Int) async throws {
@@ -148,14 +146,12 @@ enum SubjectRepository {
       }
     }
     try await db.saveSubjectPositions(subjectId: subjectId, items: items)
-    try await db.commit()
   }
 
   static func updateSubjectProgress(subjectId: Int, eps: Int?, vols: Int?) async throws {
     try await SubjectService.updateSubjectProgress(subjectId: subjectId, eps: eps, vols: vols)
     let db = try await AppContext.shared.getDB()
     try await db.updateSubjectProgress(subjectId: subjectId, eps: eps, vols: vols)
-    try await db.commit()
     await ProgressSubjectInvalidation.post(subjectId: subjectId)
   }
 
@@ -187,7 +183,6 @@ enum SubjectRepository {
       tags: tags,
       progress: progress
     )
-    try await db.commit()
     await ProgressSubjectInvalidation.post(
       subjectId: subjectId,
       mayChangeProgressMembership: true

--- a/App/Client/UserRepository.swift
+++ b/App/Client/UserRepository.swift
@@ -5,7 +5,6 @@ enum UserRepository {
     let db = try await AppContext.shared.getDB()
     let item = try await UserService.getUser(username)
     try await db.saveUser(item)
-    try await db.commit()
     return item
   }
 }

--- a/App/Components/TextInputView.swift
+++ b/App/Components/TextInputView.swift
@@ -60,7 +60,6 @@ struct TextInputView: View {
     do {
       let db = try await AppContext.shared.getDB()
       let id = try await db.saveDraft(type: type, content: content, id: currentDraftID)
-      try await db.commit()
       let drafts = try await db.fetchDrafts(type: type)
       currentDraftID = id
       self.drafts = drafts
@@ -219,7 +218,6 @@ private struct DraftBoxView: View {
                 Task {
                   if let db = try? await AppContext.shared.getDB() {
                     await db.deleteDraft(id: draft.id)
-                    try? await db.commit()
                     await onDelete()
                   }
                 }

--- a/App/Database/Operator.swift
+++ b/App/Database/Operator.swift
@@ -12,8 +12,6 @@ actor DatabaseOperator {
 
 // MARK: - basic
 extension DatabaseOperator {
-  public func commit() throws {}
-
   public func clearSubjectInterest() throws {
     try database.write { db in
       try db.execute(sql: "UPDATE subjects SET ctype = 0, collected_at = 0, interest_data = NULL")

--- a/App/Views/Discover/Search/SearchCharacterPickerView.swift
+++ b/App/Views/Discover/Search/SearchCharacterPickerView.swift
@@ -72,7 +72,6 @@ struct SearchCharacterPickerRemoteView: View {
       for item in resp.data {
         try await db.saveCharacter(item)
       }
-      try await db.commit()
       return resp
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Discover/Search/SearchCharacterView.swift
+++ b/App/Views/Discover/Search/SearchCharacterView.swift
@@ -14,7 +14,6 @@ struct SearchCharacterView: View {
       for item in resp.data {
         try await db.saveCharacter(item)
       }
-      try await db.commit()
       return resp
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Discover/Search/SearchPersonPickerView.swift
+++ b/App/Views/Discover/Search/SearchPersonPickerView.swift
@@ -72,7 +72,6 @@ struct SearchPersonPickerRemoteView: View {
       for item in resp.data {
         try await db.savePerson(item)
       }
-      try await db.commit()
       return resp
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Discover/Search/SearchPersonView.swift
+++ b/App/Views/Discover/Search/SearchPersonView.swift
@@ -14,7 +14,6 @@ struct SearchPersonView: View {
       for item in resp.data {
         try await db.savePerson(item)
       }
-      try await db.commit()
       return resp
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Discover/Search/SearchSubjectPickerView.swift
+++ b/App/Views/Discover/Search/SearchSubjectPickerView.swift
@@ -91,7 +91,6 @@ struct SearchSubjectPickerRemoteView: View {
       for item in resp.data {
         try await db.saveSubject(item)
       }
-      try await db.commit()
       return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Discover/Search/SearchSubjectView.swift
+++ b/App/Views/Discover/Search/SearchSubjectView.swift
@@ -17,7 +17,6 @@ struct SearchSubjectView: View {
       for item in resp.data {
         try await db.saveSubject(item)
       }
-      try await db.commit()
       return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Group/GroupView.swift
+++ b/App/Views/Group/GroupView.swift
@@ -81,7 +81,6 @@ struct GroupDetailView: View {
       do {
         let db = try await AppContext.shared.getDB()
         try await db.togglePinRakuenGroupCache(group: group.slim)
-        try await db.commit()
         pinnedItems = try await db.fetchRakuenGroupCache(id: "pin")
       } catch {
         Logger.app.error("Failed to toggle pin: \(error)")
@@ -105,7 +104,6 @@ struct GroupDetailView: View {
         let joinedAt = Int(Date().timeIntervalSince1970)
         let db = try await AppContext.shared.getDB()
         try await db.updateGroupJoinStatus(name: group.name, joinedAt: joinedAt)
-        try await db.commit()
         await reload()
       } catch {
         Notifier.shared.alert(error: error)
@@ -119,7 +117,6 @@ struct GroupDetailView: View {
         try await GroupService.leaveGroup(group.name)
         let db = try await AppContext.shared.getDB()
         try await db.updateGroupJoinStatus(name: group.name, joinedAt: 0)
-        try await db.commit()
         await reload()
       } catch {
         Notifier.shared.alert(error: error)

--- a/App/Views/Index/IndexRelatedPreviewView.swift
+++ b/App/Views/Index/IndexRelatedPreviewView.swift
@@ -38,7 +38,6 @@ struct IndexRelatedSubjectPreview: View {
       }
       let resp = try await SubjectService.getSubject(subjectId)
       try await db.saveSubject(resp)
-      try await db.commit()
       await loadCached()
     } catch {
       Notifier.shared.alert(error: error)
@@ -94,7 +93,6 @@ struct IndexRelatedCharacterPreview: View {
       }
       let resp = try await CharacterService.getCharacter(characterId)
       try await db.saveCharacter(resp)
-      try await db.commit()
       await loadCached()
     } catch {
       Notifier.shared.alert(error: error)
@@ -150,7 +148,6 @@ struct IndexRelatedPersonPreview: View {
       }
       let resp = try await PersonService.getPerson(personId)
       try await db.savePerson(resp)
-      try await db.commit()
       await loadCached()
     } catch {
       Notifier.shared.alert(error: error)

--- a/App/Views/Progress/ChiiProgressView.swift
+++ b/App/Views/Progress/ChiiProgressView.swift
@@ -359,14 +359,12 @@ struct ChiiProgressView: View {
         loaded[item.id] = item.type
         refreshProgress = CGFloat(count) / CGFloat(resp.total)
       }
-      try await db.commit()
       await SearchIndexing.index(resp.data.map { $0.searchable() })
       offset += limit
       if offset >= resp.total {
         break
       }
     }
-    try await db.commit()
     if since > 0 {
       checkLoadEpisodes(loaded)
     }

--- a/App/Views/Rakuen/HotGroupsView.swift
+++ b/App/Views/Rakuen/HotGroupsView.swift
@@ -28,7 +28,6 @@ struct HotGroupsView: View {
       do {
         let db = try await AppContext.shared.getDB()
         try await db.togglePinRakuenGroupCache(group: group)
-        try await db.commit()
         pinnedItems = try await db.fetchRakuenGroupCache(id: "pin")
       } catch {
         Logger.app.error("Failed to toggle pin: \(error)")
@@ -58,7 +57,6 @@ struct HotGroupsView: View {
       // Save to hot cache
       if let db = try? await AppContext.shared.getDB() {
         try await db.saveRakuenGroupCache(id: "hot", items: hotItems)
-        try await db.commit()
         cachedHotItems = hotItems
       }
     } catch {

--- a/App/Views/Rakuen/RakuenGroupTopicView.swift
+++ b/App/Views/Rakuen/RakuenGroupTopicView.swift
@@ -133,7 +133,6 @@ struct CachedGroupTopicListView: View {
       // Save to cache
       if let db = try? await AppContext.shared.getDB() {
         try await db.saveRakuenGroupTopicCache(mode: mode.rawValue, items: resp.data)
-        try await db.commit()
         cachedItems = resp.data
       }
     } catch {

--- a/App/Views/Rakuen/RakuenSubjectTopicView.swift
+++ b/App/Views/Rakuen/RakuenSubjectTopicView.swift
@@ -149,7 +149,6 @@ struct CachedSubjectTopicListView: View {
         // Save to cache
         if let db = try? await AppContext.shared.getDB() {
           try await db.saveRakuenSubjectTopicCache(mode: mode.rawValue, items: resp.data)
-          try await db.commit()
           cachedItems = resp.data
         }
       }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -291,7 +291,6 @@ struct SettingsView: View {
                 do {
                   let db = try await AppContext.shared.getDB()
                   try await db.clearDrafts()
-                  try await db.commit()
                   Notifier.shared.notify(message: "草稿箱已清空")
                 } catch {
                   Notifier.shared.alert(error: error)

--- a/App/Views/Subject/SubjectBrowsingView.swift
+++ b/App/Views/Subject/SubjectBrowsingView.swift
@@ -46,7 +46,6 @@ struct SubjectBrowsingView: View {
       for item in resp.data {
         try await db.saveSubject(item)
       }
-      try await db.commit()
       return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)
@@ -561,7 +560,6 @@ struct SubjectTagBrowsingView: View {
       for item in resp.data {
         try await db.saveSubject(item)
       }
-      try await db.commit()
       return PagedDTO(data: try await db.makeSubjectListItems(resp.data), total: resp.total)
     } catch {
       Notifier.shared.alert(error: error)


### PR DESCRIPTION
## Problem
`DatabaseOperator.commit()` no longer performs any work after the GRDB migration. Keeping the empty API and its call sites makes write flows look like they still depend on a deferred flush step.

## Approach
Remove the empty `commit()` method and all no-op call sites. Existing write behavior remains unchanged because persistence already happens inside each `database.write` boundary.

## Validation
- [x] `make build`
