### PR TITLE
feat(discover): show collection status on covers

### DIFF
--- a/App/Views/Discover/CalendarSlimView.swift
+++ b/App/Views/Discover/CalendarSlimView.swift
@@ -26,6 +26,7 @@ struct CalendarSlimView: View {
   @State private var currentDate = Calendar.current.startOfDay(for: Date())
   @State private var refreshed: Bool = false
   @State private var calendars: [CalendarEntryDTO] = []
+  @State private var collectionTypes: [Int: CollectionType] = [:]
 
   private var dates: [CalendarDay] {
     let today = currentDate
@@ -45,6 +46,12 @@ struct CalendarSlimView: View {
     return result
   }
 
+  private static func subjectIds(in calendars: [CalendarEntryDTO]) -> [Int] {
+    SubjectCollectionTypeResolver.sortedUniqueSubjectIds(
+      calendars.flatMap { $0.items.map(\.subject.id) }
+    )
+  }
+
   func updateCurrentDate() {
     let today = Calendar.current.startOfDay(for: Date())
     if currentDate != today {
@@ -58,11 +65,54 @@ struct CalendarSlimView: View {
     do {
       let db = try await AppContext.shared.getDB()
       let fetchedCalendars = try await db.fetchCalendarEntries()
+      let fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(
+        subjectIds: Self.subjectIds(in: fetchedCalendars)
+      )
       withAnimation(.default) {
         calendars = fetchedCalendars
+        collectionTypes = fetchedCollectionTypes
       }
     } catch {
       Logger.app.error("Failed to load cached calendar: \(error)")
+    }
+  }
+
+  private func loadCollectionTypes(for subjectIds: [Int], replacing: Bool = false) async {
+    let subjectIds = SubjectCollectionTypeResolver.sortedUniqueSubjectIds(subjectIds)
+    guard !subjectIds.isEmpty else {
+      if replacing {
+        withAnimation(.default) {
+          collectionTypes = [:]
+        }
+      }
+      return
+    }
+    do {
+      let fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(subjectIds: subjectIds)
+      withAnimation(.default) {
+        if replacing {
+          collectionTypes = fetchedCollectionTypes
+        } else {
+          for subjectId in subjectIds {
+            collectionTypes[subjectId] = fetchedCollectionTypes[subjectId] ?? CollectionType.none
+          }
+        }
+      }
+    } catch {
+      Logger.app.error("Failed to load calendar collection types: \(error)")
+    }
+  }
+
+  private func reloadCollectionType(subjectId: Int) async {
+    await loadCollectionTypes(for: [subjectId])
+  }
+
+  private func handleSubjectInvalidation(_ notification: Notification) {
+    guard let subjectId = ProgressSubjectInvalidation.subjectId(from: notification),
+      Self.subjectIds(in: calendars).contains(subjectId)
+    else { return }
+    Task {
+      await reloadCollectionType(subjectId: subjectId)
     }
   }
 
@@ -112,7 +162,11 @@ struct CalendarSlimView: View {
               .padding(.vertical, 3)
               .background(item.weekday.color)
               .cornerRadius(5)
-              CalendarWeekdaySlimView(calendar: item.calendar)
+              CalendarWeekdaySlimView(
+                calendar: item.calendar,
+                collectionTypes: collectionTypes,
+                reloadCollectionType: reloadCollectionType
+              )
             }
           }
           Divider()
@@ -131,11 +185,17 @@ struct CalendarSlimView: View {
     .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
       updateCurrentDate()
     }
+    .onReceive(
+      NotificationCenter.default.publisher(for: ProgressSubjectInvalidation.notificationName),
+      perform: handleSubjectInvalidation
+    )
   }
 }
 
 struct CalendarWeekdaySlimView: View {
   let calendar: CalendarEntryDTO
+  let collectionTypes: [Int: CollectionType]
+  let reloadCollectionType: (Int) async -> Void
 
   @AppStorage("subjectImageQuality") var subjectImageQuality: ImageQuality = .high
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
@@ -165,8 +225,16 @@ struct CalendarWeekdaySlimView: View {
                 Spacer(minLength: 0)
               }.padding(4)
             }
+            .imageCollectionStatus(
+              ctype: collectionTypes[item.subject.id] ?? CollectionType.none
+            )
             .imageNavLink(item.subject.link)
-            .subjectPreview(item.subject)
+            .subjectPreview(
+              item.subject,
+              collectionType: collectionTypes[item.subject.id] ?? CollectionType.none
+            ) {
+              await reloadCollectionType(item.subject.id)
+            }
         }
       }.scrollTargetLayout()
     }

--- a/App/Views/Discover/CalendarView.swift
+++ b/App/Views/Discover/CalendarView.swift
@@ -71,6 +71,7 @@ struct CalendarView: View {
   @State private var currentDate = Calendar.current.startOfDay(for: Date())
   @State private var refreshed: Bool = false
   @State private var calendars: [CalendarEntryDTO] = []
+  @State private var collectionTypes: [Int: CollectionType] = [:]
 
   var sortedCalendars: [CalendarEntryDTO] {
     let todayWeekday = WeekDay(date: currentDate).rawValue
@@ -93,15 +94,64 @@ struct CalendarView: View {
     sortedCalendars.first?.items.reduce(0) { $0 + $1.watchers } ?? 0
   }
 
+  private static func subjectIds(in calendars: [CalendarEntryDTO]) -> [Int] {
+    SubjectCollectionTypeResolver.sortedUniqueSubjectIds(
+      calendars.flatMap { $0.items.map(\.subject.id) }
+    )
+  }
+
   func loadCachedCalendar() async {
     do {
       let db = try await AppContext.shared.getDB()
       let fetchedCalendars = try await db.fetchCalendarEntries()
+      let fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(
+        subjectIds: Self.subjectIds(in: fetchedCalendars)
+      )
       withAnimation(.default) {
         calendars = fetchedCalendars
+        collectionTypes = fetchedCollectionTypes
       }
     } catch {
       Logger.app.error("Failed to load cached calendar: \(error)")
+    }
+  }
+
+  private func loadCollectionTypes(for subjectIds: [Int], replacing: Bool = false) async {
+    let subjectIds = SubjectCollectionTypeResolver.sortedUniqueSubjectIds(subjectIds)
+    guard !subjectIds.isEmpty else {
+      if replacing {
+        withAnimation(.default) {
+          collectionTypes = [:]
+        }
+      }
+      return
+    }
+    do {
+      let fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(subjectIds: subjectIds)
+      withAnimation(.default) {
+        if replacing {
+          collectionTypes = fetchedCollectionTypes
+        } else {
+          for subjectId in subjectIds {
+            collectionTypes[subjectId] = fetchedCollectionTypes[subjectId] ?? CollectionType.none
+          }
+        }
+      }
+    } catch {
+      Logger.app.error("Failed to load calendar collection types: \(error)")
+    }
+  }
+
+  private func reloadCollectionType(subjectId: Int) async {
+    await loadCollectionTypes(for: [subjectId])
+  }
+
+  private func handleSubjectInvalidation(_ notification: Notification) {
+    guard let subjectId = ProgressSubjectInvalidation.subjectId(from: notification),
+      Self.subjectIds(in: calendars).contains(subjectId)
+    else { return }
+    Task {
+      await reloadCollectionType(subjectId: subjectId)
     }
   }
 
@@ -148,7 +198,11 @@ struct CalendarView: View {
           }.padding(.horizontal, 8)
           VStack {
             ForEach(sortedCalendars) { calendar in
-              CalendarWeekdayView(calendar: calendar)
+              CalendarWeekdayView(
+                calendar: calendar,
+                collectionTypes: collectionTypes,
+                reloadCollectionType: reloadCollectionType
+              )
                 .padding(.vertical, 10)
             }
           }.padding(.horizontal, 8)
@@ -173,11 +227,17 @@ struct CalendarView: View {
     .onReceive(NotificationCenter.default.publisher(for: .NSCalendarDayChanged)) { _ in
       updateCurrentDate()
     }
+    .onReceive(
+      NotificationCenter.default.publisher(for: ProgressSubjectInvalidation.notificationName),
+      perform: handleSubjectInvalidation
+    )
   }
 }
 
 struct CalendarWeekdayView: View {
   let calendar: CalendarEntryDTO
+  let collectionTypes: [Int: CollectionType]
+  let reloadCollectionType: (Int) async -> Void
 
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
@@ -222,8 +282,16 @@ struct CalendarWeekdayView: View {
                   Spacer(minLength: 0)
                 }.padding(4)
               }
+              .imageCollectionStatus(
+                ctype: collectionTypes[item.subject.id] ?? CollectionType.none
+              )
               .imageNavLink(item.subject.link)
-              .subjectPreview(item.subject)
+              .subjectPreview(
+                item.subject,
+                collectionType: collectionTypes[item.subject.id] ?? CollectionType.none
+              ) {
+                await reloadCollectionType(item.subject.id)
+              }
           }
         }
       }

--- a/App/Views/Discover/TrendingSubjectView.swift
+++ b/App/Views/Discover/TrendingSubjectView.swift
@@ -1,3 +1,4 @@
+import OSLog
 import SwiftUI
 
 struct TrendingSubjectView: View {
@@ -43,6 +44,7 @@ struct TrendingSubjectTypeView: View {
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   @State private var items: [TrendingSubjectDTO] = []
+  @State private var collectionTypes: [Int: CollectionType] = [:]
 
   var columnCount: Int {
     let count = Int(width / 320)
@@ -66,6 +68,10 @@ struct TrendingSubjectTypeView: View {
 
   var smallItems: [TrendingSubjectDTO] {
     return Array(items.dropFirst(largeItems.count))
+  }
+
+  private static func subjectIds(in items: [TrendingSubjectDTO]) -> [Int] {
+    SubjectCollectionTypeResolver.sortedUniqueSubjectIds(items.map(\.subject.id))
   }
 
   var body: some View {
@@ -104,8 +110,16 @@ struct TrendingSubjectTypeView: View {
                   Spacer(minLength: 0)
                 }.padding(8)
               }
+              .imageCollectionStatus(
+                ctype: collectionTypes[item.subject.id] ?? CollectionType.none
+              )
               .imageNavLink(item.subject.link)
-              .subjectPreview(item.subject)
+              .subjectPreview(
+                item.subject,
+                collectionType: collectionTypes[item.subject.id] ?? CollectionType.none
+              ) {
+                await reloadCollectionType(subjectId: item.subject.id)
+              }
           }
         }
         ScrollView(.horizontal, showsIndicators: false) {
@@ -131,8 +145,16 @@ struct TrendingSubjectTypeView: View {
                     Spacer(minLength: 0)
                   }.padding(4)
                 }
+                .imageCollectionStatus(
+                  ctype: collectionTypes[item.subject.id] ?? CollectionType.none
+                )
                 .imageNavLink(item.subject.link)
-                .subjectPreview(item.subject)
+                .subjectPreview(
+                  item.subject,
+                  collectionType: collectionTypes[item.subject.id] ?? CollectionType.none
+                ) {
+                  await reloadCollectionType(subjectId: item.subject.id)
+                }
             }
           }.scrollTargetLayout()
         }
@@ -143,17 +165,53 @@ struct TrendingSubjectTypeView: View {
     .task(id: "\(type.rawValue)-\(reloader)") {
       await loadCached()
     }
+    .onReceive(
+      NotificationCenter.default.publisher(for: ProgressSubjectInvalidation.notificationName),
+      perform: handleSubjectInvalidation
+    )
   }
 
   private func loadCached() async {
     do {
       let db = try await AppContext.shared.getDB()
       let fetchedItems = try await db.fetchTrendingSubjects(type: type)
+      let fetchedCollectionTypes: [Int: CollectionType]
+      do {
+        fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(
+          subjectIds: Self.subjectIds(in: fetchedItems)
+        )
+      } catch {
+        Logger.app.error("Failed to load trending collection types: \(error)")
+        fetchedCollectionTypes = [:]
+      }
       withAnimation(.default) {
         items = fetchedItems
+        collectionTypes = fetchedCollectionTypes
       }
     } catch {
       Notifier.shared.alert(error: error)
+    }
+  }
+
+  private func reloadCollectionType(subjectId: Int) async {
+    do {
+      let fetchedCollectionTypes = try await SubjectCollectionTypeResolver.load(
+        subjectIds: [subjectId]
+      )
+      withAnimation(.default) {
+        collectionTypes[subjectId] = fetchedCollectionTypes[subjectId] ?? CollectionType.none
+      }
+    } catch {
+      Logger.app.error("Failed to load trending collection type: \(error)")
+    }
+  }
+
+  private func handleSubjectInvalidation(_ notification: Notification) {
+    guard let subjectId = ProgressSubjectInvalidation.subjectId(from: notification),
+      Self.subjectIds(in: items).contains(subjectId)
+    else { return }
+    Task {
+      await reloadCollectionType(subjectId: subjectId)
     }
   }
 }

--- a/App/Views/Subject/SubjectCardView.swift
+++ b/App/Views/Subject/SubjectCardView.swift
@@ -349,20 +349,83 @@ struct SubjectCardView: View {
 }
 
 extension View {
-  func subjectPreview(_ subject: SlimSubjectDTO, eps: Bool = false) -> some View {
-    self.contextMenu {
-      NavigationLink(value: NavDestination.subject(subject.id)) {
-        Label("查看详情", systemImage: "magnifyingglass")
-      }
-      if eps, subject.type == .anime || subject.type == .real {
-        NavigationLink(value: NavDestination.episodeList(subject.id)) {
-          Label("章节列表", systemImage: "list.bullet")
+  func subjectPreview(
+    _ subject: SlimSubjectDTO,
+    eps: Bool = false,
+    collectionType: CollectionType? = nil,
+    onCollectionSaved: (() async -> Void)? = nil
+  ) -> some View {
+    modifier(
+      SubjectPreviewModifier(
+        subject: subject,
+        eps: eps,
+        collectionType: collectionType,
+        onCollectionSaved: onCollectionSaved
+      )
+    )
+  }
+}
+
+private struct SubjectPreviewModifier: ViewModifier {
+  let subject: SlimSubjectDTO
+  let eps: Bool
+  let collectionType: CollectionType?
+  let onCollectionSaved: (() async -> Void)?
+
+  @AppStorage("isAuthenticated") private var isAuthenticated: Bool = false
+  @State private var showCollectionBox = false
+
+  private var showsCollectionAction: Bool {
+    guard let collectionType else { return false }
+    return isAuthenticated || collectionType != CollectionType.none
+  }
+
+  private var collectionActionTitle: String {
+    collectionType == CollectionType.none ? "收藏" : "修改收藏"
+  }
+
+  private var collectionActionIcon: String {
+    collectionType == CollectionType.none ? "plus" : "square.and.pencil"
+  }
+
+  func body(content: Content) -> some View {
+    content
+      .contextMenu {
+        NavigationLink(value: NavDestination.subject(subject.id)) {
+          Label("查看详情", systemImage: "magnifyingglass")
         }
+        if eps, subject.type == .anime || subject.type == .real {
+          NavigationLink(value: NavDestination.episodeList(subject.id)) {
+            Label("章节列表", systemImage: "list.bullet")
+          }
+        }
+        if showsCollectionAction {
+          Button {
+            showCollectionBox = true
+          } label: {
+            Label(collectionActionTitle, systemImage: collectionActionIcon)
+          }
+          .disabled(!isAuthenticated)
+        }
+      } preview: {
+        SubjectCardView(subject: subject)
+          .padding()
+          .frame(idealWidth: 360)
       }
-    } preview: {
-      SubjectCardView(subject: subject)
-        .padding()
-        .frame(idealWidth: 360)
-    }
+      .sheet(isPresented: $showCollectionBox) {
+        SubjectCollectionBoxView(subjectId: subject.id, onSaved: onCollectionSaved)
+      }
+  }
+}
+
+enum SubjectCollectionTypeResolver {
+  static func load(subjectIds: [Int]) async throws -> [Int: CollectionType] {
+    guard !subjectIds.isEmpty else { return [:] }
+    let db = try await AppContext.shared.getDB()
+    return try await db.getCollectionTypes(subjectIds: subjectIds)
+  }
+
+  static func sortedUniqueSubjectIds(_ subjectIds: [Int]) -> [Int] {
+    Array(Set(subjectIds)).sorted()
   }
 }


### PR DESCRIPTION
## Summary

- Show local collection status badges on calendar and trending subject covers in Discover.
- Add a collection action to the subject cover context menu so users can add or edit collection state from those surfaces.
- Refresh the affected cover badge after collection edits or subject progress invalidations without reloading the remote page data.

## Validation

- `make build`
- `git diff --check`
