### PR TITLE
feat(discover): persist trending and browse state

### DIFF
--- a/App/Views/Discover/TrendingSubjectView.swift
+++ b/App/Views/Discover/TrendingSubjectView.swift
@@ -1,9 +1,74 @@
+import Foundation
 import OSLog
 import SwiftUI
+
+private struct TrendingSubjectCollapseState: Equatable, RawRepresentable {
+  typealias RawValue = String
+
+  private var collapsedTypeValues: Set<Int> = []
+
+  subscript(type: SubjectType) -> Bool {
+    get {
+      collapsedTypeValues.contains(type.rawValue)
+    }
+    set {
+      if newValue {
+        collapsedTypeValues.insert(type.rawValue)
+      } else {
+        collapsedTypeValues.remove(type.rawValue)
+      }
+    }
+  }
+
+  var rawValue: String {
+    let dict: [String: Any] = [
+      "collapsedTypes": collapsedTypeValues.sorted()
+    ]
+    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+    return json
+  }
+
+  init?(rawValue: String) {
+    guard !rawValue.isEmpty else {
+      self.init()
+      return
+    }
+    guard let data = rawValue.data(using: .utf8),
+      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      self.init()
+      return
+    }
+    let rawTypes = dict["collapsedTypes"] as? [Any] ?? []
+    self.init()
+    self.collapsedTypeValues = Set(rawTypes.compactMap(Self.decodeTypeValue))
+  }
+
+  init() {}
+
+  private static func decodeTypeValue(_ value: Any) -> Int? {
+    if let value = value as? Int {
+      return value
+    }
+    if let value = value as? String {
+      return Int(value)
+    }
+    if let value = value as? NSNumber {
+      return value.intValue
+    }
+    return nil
+  }
+}
 
 struct TrendingSubjectView: View {
   let width: CGFloat
 
+  @AppStorage("trendingSubjectCollapseState")
+  private var collapseState: TrendingSubjectCollapseState = TrendingSubjectCollapseState()
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   @State private var loaded: Bool = false
@@ -26,8 +91,9 @@ struct TrendingSubjectView: View {
 
   var body: some View {
     VStack(spacing: 24) {
-      ForEach(SubjectType.allTypes) { st in
-        TrendingSubjectTypeView(type: st, width: width - 16, reloader: reloader)
+      ForEach(SubjectType.allTypes) { type in
+        TrendingSubjectTypeView(
+          type: type, width: width - 16, reloader: reloader, collapseState: $collapseState)
       }
     }
     .padding(.horizontal, 8)
@@ -35,10 +101,11 @@ struct TrendingSubjectView: View {
   }
 }
 
-struct TrendingSubjectTypeView: View {
+private struct TrendingSubjectTypeView: View {
   let type: SubjectType
   let width: CGFloat
   let reloader: Bool
+  @Binding var collapseState: TrendingSubjectCollapseState
 
   @AppStorage("subjectImageQuality") var subjectImageQuality: ImageQuality = .high
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
@@ -74,20 +141,19 @@ struct TrendingSubjectTypeView: View {
     SubjectCollectionTypeResolver.sortedUniqueSubjectIds(items.map(\.subject.id))
   }
 
+  private var isCollapsed: Bool {
+    collapseState[type]
+  }
+
   var body: some View {
     VStack(spacing: 8) {
-      if items.isEmpty {
+      TrendingSubjectTypeHeader(type: type, collapseState: $collapseState)
+
+      if isCollapsed {
+        EmptyView()
+      } else if items.isEmpty {
         ProgressView()
       } else {
-        VStack(spacing: 5) {
-          HStack {
-            Text("\(type.description)").font(.title)
-            Spacer()
-            NavigationLink(value: NavDestination.subjectBrowsing(type)) {
-              Text("更多 »")
-            }.buttonStyle(.navigation)
-          }
-        }
         HStack {
           ForEach(largeItems) { item in
             ImageView(img: item.subject.images?.resize(subjectImageQuality.largeSize))
@@ -212,6 +278,42 @@ struct TrendingSubjectTypeView: View {
     else { return }
     Task {
       await reloadCollectionType(subjectId: subjectId)
+    }
+  }
+}
+
+private struct TrendingSubjectTypeHeader: View {
+  let type: SubjectType
+  @Binding var collapseState: TrendingSubjectCollapseState
+
+  private var isCollapsed: Bool {
+    collapseState[type]
+  }
+
+  var body: some View {
+    HStack {
+      Button {
+        withAnimation(.default) {
+          collapseState[type].toggle()
+        }
+      } label: {
+        Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+          .font(.headline)
+          .frame(width: 28, height: 28)
+          .contentShape(Rectangle())
+          .accessibilityLabel(isCollapsed ? "展开" : "收起")
+      }
+      .buttonStyle(.plain)
+
+      Text(type.description)
+        .font(.title)
+
+      Spacer()
+
+      NavigationLink(value: NavDestination.subjectBrowsing(type)) {
+        Text("更多 »")
+      }
+      .buttonStyle(.navigation)
     }
   }
 }

--- a/App/Views/Subject/SubjectBrowsingView.swift
+++ b/App/Views/Subject/SubjectBrowsingView.swift
@@ -9,15 +9,136 @@ enum FilterExpand: String {
   case sort = "sort"
 }
 
+private struct SubjectBrowsingOptions: Equatable, RawRepresentable {
+  typealias RawValue = String
+
+  var filter: SubjectsBrowseFilter = SubjectsBrowseFilter()
+  var sort: SubjectSortMode = .rank
+
+  var rawValue: String {
+    let dict: [String: String] = [
+      "filter": Self.encodeFilter(filter),
+      "sort": sort.rawValue,
+    ]
+    guard let data = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+    return json
+  }
+
+  init?(rawValue: String) {
+    guard !rawValue.isEmpty else {
+      return nil
+    }
+    guard let data = rawValue.data(using: .utf8),
+      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+    else {
+      return nil
+    }
+    self.filter = Self.decodeFilter(dict["filter"] ?? "")
+    self.sort = SubjectSortMode(rawValue: dict["sort"] ?? "") ?? .rank
+  }
+
+  init() {}
+
+  private static func encodeFilter(_ filter: SubjectsBrowseFilter) -> String {
+    guard let data = try? JSONEncoder().encode(filter),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+    return json
+  }
+
+  private static func decodeFilter(_ rawValue: String) -> SubjectsBrowseFilter {
+    guard let data = rawValue.data(using: .utf8),
+      let filter = try? JSONDecoder().decode(SubjectsBrowseFilter.self, from: data)
+    else {
+      return SubjectsBrowseFilter()
+    }
+    return filter
+  }
+}
+
+private struct SubjectBrowsingOptionsState: Equatable, RawRepresentable {
+  typealias RawValue = String
+
+  private var rawOptionsByType: [String: String] = [:]
+
+  subscript(type: SubjectType) -> SubjectBrowsingOptions {
+    get {
+      SubjectBrowsingOptions(rawValue: rawOptionsByType[String(type.rawValue)] ?? "")
+        ?? SubjectBrowsingOptions()
+    }
+    set {
+      let key = String(type.rawValue)
+      if newValue == SubjectBrowsingOptions() {
+        rawOptionsByType.removeValue(forKey: key)
+      } else {
+        rawOptionsByType[key] = newValue.rawValue
+      }
+    }
+  }
+
+  var rawValue: String {
+    guard let data = try? JSONSerialization.data(
+      withJSONObject: rawOptionsByType,
+      options: [.sortedKeys]
+    ),
+      let json = String(data: data, encoding: .utf8)
+    else {
+      return "{}"
+    }
+    return json
+  }
+
+  init?(rawValue: String) {
+    guard !rawValue.isEmpty else {
+      self.init()
+      return
+    }
+    guard let data = rawValue.data(using: .utf8),
+      let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+    else {
+      self.init()
+      return
+    }
+    self.init()
+    self.rawOptionsByType = dict
+  }
+
+  init() {}
+}
+
 struct SubjectBrowsingView: View {
   let type: SubjectType
 
   @State private var showFilter: Bool = false
   @State private var filterExpand: FilterExpand? = nil
-  @State private var filter: SubjectsBrowseFilter = SubjectsBrowseFilter()
-  @State private var sort: SubjectSortMode = .rank
+  @AppStorage("subjectBrowsingOptionsState")
+  private var optionsState: SubjectBrowsingOptionsState = SubjectBrowsingOptionsState()
 
   @State private var reloader: Bool = false
+
+  private var options: SubjectBrowsingOptions {
+    optionsState[type]
+  }
+
+  private var filterBinding: Binding<SubjectsBrowseFilter> {
+    Binding(
+      get: { optionsState[type].filter },
+      set: { optionsState[type].filter = $0 }
+    )
+  }
+
+  private var sortBinding: Binding<SubjectSortMode> {
+    Binding(
+      get: { optionsState[type].sort },
+      set: { optionsState[type].sort = $0 }
+    )
+  }
 
   var categories: [PlatformInfo] {
     var categories: [Int: PlatformInfo]
@@ -42,7 +163,7 @@ struct SubjectBrowsingView: View {
         throw ChiiError.uninitialized
       }
       let resp = try await SubjectService.getSubjects(
-        type: type, sort: sort, filter: filter, page: page)
+        type: type, sort: options.sort, filter: options.filter, page: page)
       for item in resp.data {
         try await db.saveSubject(item)
       }
@@ -63,7 +184,7 @@ struct SubjectBrowsingView: View {
 
   private func sortBadge() -> some View {
     BadgeView(background: .accent, padding: 4) {
-      Label(sort.description, systemImage: sort.icon)
+      Label(options.sort.description, systemImage: options.sort.icon)
         .font(.caption)
         .labelStyle(.compact)
     }
@@ -74,25 +195,25 @@ struct SubjectBrowsingView: View {
       HFlow {
         Label("筛选", systemImage: "line.3.horizontal.decrease.circle")
         // cat
-        if let cat = filter.cat {
+        if let cat = options.filter.cat {
           filterBadge(cat.typeCN)
         }
 
         // series
-        if let series = filter.series {
+        if let series = options.filter.series {
           filterBadge(series ? "系列" : "单行本")
         }
 
         // tags
-        if let tags = filter.tags {
+        if let tags = options.filter.tags {
           ForEach(tags, id: \.self) { tag in
             filterBadge(tag)
           }
         }
 
         // date
-        if let year = filter.year {
-          if let month = filter.month {
+        if let year = options.filter.year {
+          if let month = options.filter.month {
             filterBadge("\(String(year))年\(String(month))月")
           } else {
             filterBadge("\(String(year))年")
@@ -127,7 +248,7 @@ struct SubjectBrowsingView: View {
 
       }.padding(.horizontal, 8)
     }
-    .onChange(of: sort) { _, _ in
+    .onChange(of: options.sort) { _, _ in
       withAnimation(.default) {
         reloader.toggle()
       }
@@ -135,7 +256,7 @@ struct SubjectBrowsingView: View {
     .navigationTitle("全部\(type.description)")
     .navigationBarTitleDisplayMode(.inline)
     .sheet(isPresented: $showFilter) {
-      SubjectBrowsingFilterView(type: type, filter: $filter, categories: categories)
+      SubjectBrowsingFilterView(type: type, filter: filterBinding, categories: categories)
     }
     .onChange(of: showFilter) {
       if !showFilter {
@@ -154,7 +275,7 @@ struct SubjectBrowsingView: View {
           Image(systemName: "line.3.horizontal.decrease")
         }
         Menu {
-          Picker("排序", selection: $sort.animated()) {
+          Picker("排序", selection: sortBinding.animated()) {
             ForEach(SubjectSortMode.allCases, id: \.self) { sortMode in
               Label(sortMode.description, systemImage: sortMode.icon).tag(sortMode)
             }


### PR DESCRIPTION
## Summary
- add per-type collapse controls for Discover trending sections, persisted in a single AppStorage-backed preference
- persist subject browse filter and sort selections by subject type
- keep AppStorage serialization in dedicated RawRepresentable storage wrappers so Codable API filters keep their request payload shape

## Validation
- `git diff --check`
- `make build`
