### PR TITLE
refactor(ui): unify sheet presentation

### DIFF
--- a/App/Components/BBCodeEditor.swift
+++ b/App/Components/BBCodeEditor.swift
@@ -444,10 +444,9 @@ struct BBCodeEditor: View {
         start: $inputColorStart,
         end: $inputColorEnd,
         gradient: $inputColorGradient,
-        show: $showingColorInput,
         handleColorInput: handleColorInput,
         handleGradientInput: handleGradientInput
-      ).presentationDetents([.medium])
+      )
     }
     .sheet(isPresented: $showingEmojiInput) {
       SmileyPicker { code in
@@ -532,7 +531,6 @@ private struct BBCodeToolbarSeparator: View {
 }
 
 private struct SmileyPicker: View {
-  @Environment(\.dismiss) private var dismiss
   let onSelect: (String) -> Void
 
   @State private var selectedSectionKey = SmileyCatalog.sections.first?.key ?? ""
@@ -560,7 +558,7 @@ private struct SmileyPicker: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "", size: .both) {
       ScrollView {
         VStack(alignment: .leading, spacing: 16) {
           ScrollView(.horizontal, showsIndicators: false) {
@@ -607,19 +605,7 @@ private struct SmileyPicker: View {
         }
         .padding()
       }
-      .navigationTitle("")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Image(systemName: "xmark")
-          }
-        }
-      }
     }
-    .presentationDetents([.medium, .large])
   }
 }
 
@@ -867,10 +853,11 @@ struct GradientColor {
 }
 
 struct ColorEditor: View {
+  @Environment(\.dismiss) private var dismiss
+
   @Binding var start: Color
   @Binding var end: Color
   @Binding var gradient: Bool
-  @Binding var show: Bool
 
   let handleColorInput: () -> Void
   let handleGradientInput: () -> Void
@@ -887,26 +874,34 @@ struct ColorEditor: View {
   ]
 
   var body: some View {
-    ScrollView {
-      VStack {
-        HStack {
-          Button("取消") {
-            show = false
-            gradient = false
-          }
-          .adaptiveButtonStyle(.bordered)
-          Spacer()
-          Button("确定") {
-            if gradient {
-              handleGradientInput()
-            } else {
-              handleColorInput()
-            }
-            show = false
-            gradient = false
-          }
-          .adaptiveButtonStyle(.borderedProminent)
+    SheetView(
+      title: "颜色",
+      size: .medium,
+      onClose: {
+        gradient = false
+      }
+    ) {
+      ScrollView {
+        VStack {
+          colorContent
         }
+        .padding()
+      }
+    } controls: {
+      Button("确定") {
+        if gradient {
+          handleGradientInput()
+        } else {
+          handleColorInput()
+        }
+        gradient = false
+        dismiss()
+      }
+    }
+  }
+
+  private var colorContent: some View {
+    VStack {
         HStack {
           ColorPicker("", selection: $start)
             .labelsHidden()
@@ -953,8 +948,7 @@ struct ColorEditor: View {
               }
             }
           }
-        }
-      }.padding()
+      }
     }
   }
 }

--- a/App/Components/CommentItemView.swift
+++ b/App/Components/CommentItemView.swift
@@ -505,7 +505,7 @@ struct CreateCommentBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: title, closeDisabled: updating) {
       ScrollView {
         VStack {
           TextInputView(type: "回复", text: $content)
@@ -522,29 +522,16 @@ struct CreateCommentBoxSheet: View {
             }
         }.padding()
       }
-      .navigationTitle(title)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(updating)
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          showTurnstile = true
+        } label: {
+          Label("发送", systemImage: "paperplane")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              showTurnstile = true
-            } label: {
-              Label("发送", systemImage: "paperplane")
-            }
-            .disabled(content.isEmpty)
-          }
-        }
+        .disabled(content.isEmpty)
       }
     }
   }
@@ -605,7 +592,7 @@ struct EditCommentBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: title, closeDisabled: updating) {
       ScrollView {
         VStack {
           TextInputView(type: "回复", text: $content)
@@ -613,31 +600,18 @@ struct EditCommentBoxSheet: View {
             .disabled(updating)
         }.padding()
       }
-      .navigationTitle(title)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          Task {
+            await editComment(content: content)
           }
-          .disabled(updating)
+        } label: {
+          Label("保存", systemImage: "checkmark")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              Task {
-                await editComment(content: content)
-              }
-            } label: {
-              Label("保存", systemImage: "checkmark")
-            }
-            .disabled(content.isEmpty)
-          }
-        }
+        .disabled(content.isEmpty)
       }
     }
   }

--- a/App/Components/IndexPickerView.swift
+++ b/App/Components/IndexPickerView.swift
@@ -52,7 +52,7 @@ struct IndexPickerSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "选择目录", size: .both) {
       VStack {
         if loading {
           ProgressView("加载目录中...")
@@ -89,19 +89,7 @@ struct IndexPickerSheet: View {
           }
         }
       }
-      .navigationTitle("选择目录")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .topBarTrailing) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-        }
-      }
     }
-    .presentationDetents([.medium, .large])
     .task {
       await loadUserIndexes()
     }

--- a/App/Components/ReportView.swift
+++ b/App/Components/ReportView.swift
@@ -32,7 +32,7 @@ struct ReportSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "报告疑虑", size: .both, closeDisabled: submitting) {
       ScrollView {
         VStack(alignment: .leading, spacing: 16) {
           VStack(alignment: .leading, spacing: 8) {
@@ -94,28 +94,15 @@ struct ReportSheet: View {
         }
         .padding()
       }
-      .navigationTitle("报告疑虑")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(submitting)
+    } controls: {
+      Button {
+        Task {
+          await submitReport()
         }
-        ToolbarItem(placement: .confirmationAction) {
-          Button {
-            Task {
-              await submitReport()
-            }
-          } label: {
-            Label("提交", systemImage: "paperplane")
-          }
-          .disabled(submitting || comment.count > 2000)
-        }
+      } label: {
+        Label("提交", systemImage: "paperplane")
       }
-    }.presentationDetents([.medium, .large])
+      .disabled(submitting || comment.count > 2000)
+    }
   }
 }

--- a/App/Components/SheetView.swift
+++ b/App/Components/SheetView.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+enum SheetPresentationSize {
+  case medium
+  case large
+  case both
+
+  var detents: Set<PresentationDetent> {
+    switch self {
+    case .medium:
+      [.medium]
+    case .large:
+      [.large]
+    case .both:
+      [.medium, .large]
+    }
+  }
+}
+
+struct SheetView<Content: View, Controls: View>: View {
+  let title: String?
+  let size: SheetPresentationSize
+  let closeTitle: String
+  let showsCloseButton: Bool
+  let closeDisabled: Bool
+  let onClose: (() -> Void)?
+  let controlsPlacement: ToolbarItemPlacement
+  let applyFormStyle: Bool
+  let content: Content
+  let controls: Controls?
+
+  @Environment(\.dismiss) private var dismiss
+
+  init(
+    title: String? = nil,
+    size: SheetPresentationSize = .large,
+    closeTitle: String = "取消",
+    showsCloseButton: Bool = true,
+    closeDisabled: Bool = false,
+    onClose: (() -> Void)? = nil,
+    controlsPlacement: ToolbarItemPlacement = .confirmationAction,
+    applyFormStyle: Bool = false,
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder controls: () -> Controls
+  ) {
+    self.title = title
+    self.size = size
+    self.closeTitle = closeTitle
+    self.showsCloseButton = showsCloseButton
+    self.closeDisabled = closeDisabled
+    self.onClose = onClose
+    self.controlsPlacement = controlsPlacement
+    self.applyFormStyle = applyFormStyle
+    self.content = content()
+    self.controls = controls()
+  }
+
+  init(
+    title: String? = nil,
+    size: SheetPresentationSize = .large,
+    closeTitle: String = "取消",
+    showsCloseButton: Bool = true,
+    closeDisabled: Bool = false,
+    onClose: (() -> Void)? = nil,
+    applyFormStyle: Bool = false,
+    @ViewBuilder content: () -> Content
+  ) where Controls == EmptyView {
+    self.title = title
+    self.size = size
+    self.closeTitle = closeTitle
+    self.showsCloseButton = showsCloseButton
+    self.closeDisabled = closeDisabled
+    self.onClose = onClose
+    controlsPlacement = .confirmationAction
+    self.applyFormStyle = applyFormStyle
+    self.content = content()
+    controls = nil
+  }
+
+  var body: some View {
+    NavigationStack {
+      sheetContent
+        .navigationTitle(title ?? "")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+          if showsCloseButton {
+            ToolbarItem(placement: .cancellationAction) {
+              Button {
+                onClose?()
+                dismiss()
+              } label: {
+                Label(closeTitle, systemImage: "xmark")
+              }
+              .disabled(closeDisabled)
+            }
+          }
+          if let controls {
+            ToolbarItemGroup(placement: controlsPlacement) {
+              controls
+            }
+          }
+        }
+    }
+    .presentationDetents(size.detents)
+  }
+
+  @ViewBuilder
+  private var sheetContent: some View {
+    if applyFormStyle {
+      content
+        .formStyle(.grouped)
+        .scrollContentBackground(.hidden)
+    } else {
+      content
+    }
+  }
+}

--- a/App/Components/TextInputView.swift
+++ b/App/Components/TextInputView.swift
@@ -187,7 +187,7 @@ private struct DraftBoxView: View {
   @Binding var isPresented: Bool
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "草稿箱", size: .medium, closeTitle: "关闭") {
       List {
         ForEach(drafts) { draft in
           if draft.id == currentID {
@@ -228,15 +228,6 @@ private struct DraftBoxView: View {
           }
         }
       }
-      .navigationTitle("草稿箱")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .topBarTrailing) {
-          Button("关闭", role: .cancel) {
-            isPresented = false
-          }
-        }
-      }
-    }.presentationDetents([.medium])
+    }
   }
 }

--- a/App/Components/TopicReplyView.swift
+++ b/App/Components/TopicReplyView.swift
@@ -480,7 +480,7 @@ struct CreateReplyBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: title, closeDisabled: updating) {
       ScrollView {
         VStack {
           TextInputView(type: "回复", text: $content)
@@ -497,29 +497,16 @@ struct CreateReplyBoxSheet: View {
             }
         }.padding()
       }
-      .navigationTitle(title)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(updating)
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          showTurnstile = true
+        } label: {
+          Label("发送", systemImage: "paperplane")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              showTurnstile = true
-            } label: {
-              Label("发送", systemImage: "paperplane")
-            }
-            .disabled(content.isEmpty)
-          }
-        }
+        .disabled(content.isEmpty)
       }
     }
   }
@@ -582,7 +569,7 @@ struct EditReplyBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: title, closeDisabled: updating) {
       ScrollView {
         VStack {
           TextInputView(type: "回复", text: $content)
@@ -590,31 +577,18 @@ struct EditReplyBoxSheet: View {
             .disabled(updating)
         }.padding()
       }
-      .navigationTitle(title)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          Task {
+            await editReply(content: content)
           }
-          .disabled(updating)
+        } label: {
+          Label("保存", systemImage: "checkmark")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              Task {
-                await editReply(content: content)
-              }
-            } label: {
-              Label("保存", systemImage: "checkmark")
-            }
-            .disabled(content.isEmpty)
-          }
-        }
+        .disabled(content.isEmpty)
       }
     }
   }
@@ -658,7 +632,7 @@ struct CreateTopicBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: header, closeDisabled: updating) {
       ScrollView {
         VStack {
           BorderView(color: .secondary.opacity(0.2), padding: 4) {
@@ -681,29 +655,16 @@ struct CreateTopicBoxSheet: View {
             }
         }.padding()
       }
-      .navigationTitle(header)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(updating)
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          showTurnstile = true
+        } label: {
+          Label("发送", systemImage: "paperplane")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              showTurnstile = true
-            } label: {
-              Label("发送", systemImage: "paperplane")
-            }
-            .disabled(title.isEmpty || content.isEmpty)
-          }
-        }
+        .disabled(title.isEmpty || content.isEmpty)
       }
     }
   }
@@ -768,7 +729,7 @@ struct EditTopicBoxSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: header, closeDisabled: updating) {
       ScrollView {
         VStack {
           if post == nil {
@@ -794,31 +755,18 @@ struct EditTopicBoxSheet: View {
             .disabled(updating)
         }.padding()
       }
-      .navigationTitle(header)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
+    } controls: {
+      if updating {
+        ProgressView()
+      } else {
+        Button {
+          Task {
+            await editTopic(title: title, content: content)
           }
-          .disabled(updating)
+        } label: {
+          Label("保存", systemImage: "checkmark")
         }
-        ToolbarItem(placement: .confirmationAction) {
-          if updating {
-            ProgressView()
-          } else {
-            Button {
-              Task {
-                await editTopic(title: title, content: content)
-              }
-            } label: {
-              Label("保存", systemImage: "checkmark")
-            }
-            .disabled(submitDisabled)
-          }
-        }
+        .disabled(submitDisabled)
       }
     }
   }

--- a/App/Components/TurnstileView.swift
+++ b/App/Components/TurnstileView.swift
@@ -89,13 +89,12 @@ struct TurnstileSheetView: View {
   @Environment(\.dismiss) private var dismiss
 
   var body: some View {
-    ScrollView {
+    SheetView(title: "请完成验证", size: .medium, showsCloseButton: false) {
       VStack {
-        Text("请完成验证")
-          .font(.headline)
         TrunstileView(token: $token)
           .frame(width: 300, height: 65)
       }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
       .padding()
       .onChange(of: token) {
         if !token.isEmpty {
@@ -103,6 +102,6 @@ struct TurnstileSheetView: View {
           onSuccess()
         }
       }
-    }.presentationDetents([.medium])
+    }
   }
 }

--- a/App/Helpers/Navigation.swift
+++ b/App/Helpers/Navigation.swift
@@ -34,7 +34,6 @@ enum NavDestination: Hashable, View {
   case infobox(_ title: String, _ infobox: Infobox)
 
   case subject(_ subjectId: Int)
-  case subjectRating(_ subject: SubjectDTO)
   case subjectRelationList(_ subjectId: Int)
   case subjectCharacterList(_ subjectId: Int)
   case subjectStaffList(_ subjectId: Int)
@@ -113,8 +112,6 @@ enum NavDestination: Hashable, View {
 
     case .subject(let subjectId):
       SubjectView(subjectId: subjectId)
-    case .subjectRating(let subject):
-      SubjectRatingView(subject: subject)
     case .subjectRelationList(let subjectId):
       SubjectRelationListView(subjectId: subjectId)
     case .subjectCharacterList(let subjectId):

--- a/App/Views/Discover/Search/SearchCharacterPickerView.swift
+++ b/App/Views/Discover/Search/SearchCharacterPickerView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct SearchCharacterPickerView: View {
-  @Environment(\.dismiss) var dismiss
-
   let onSelect: (Int) -> Void
 
   @State private var searchText: String = ""
@@ -11,7 +9,7 @@ struct SearchCharacterPickerView: View {
   @State private var showsResults = false
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "搜索角色") {
       ScrollView {
         VStack {
           if !showsResults {
@@ -27,8 +25,6 @@ struct SearchCharacterPickerView: View {
           }
         }.padding()
       }
-      .navigationTitle("搜索角色")
-      .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索角色")
       .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
@@ -53,19 +49,9 @@ struct SearchCharacterPickerView: View {
           }
         }
       }
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Image(systemName: remote ? "globe" : "internaldrive")
-            .foregroundColor(remote ? .blue : .green)
-        }
-      }
+    } controls: {
+      Image(systemName: remote ? "globe" : "internaldrive")
+        .foregroundColor(remote ? .blue : .green)
     }
   }
 }

--- a/App/Views/Discover/Search/SearchPersonPickerView.swift
+++ b/App/Views/Discover/Search/SearchPersonPickerView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct SearchPersonPickerView: View {
-  @Environment(\.dismiss) var dismiss
-
   let onSelect: (Int) -> Void
 
   @State private var searchText: String = ""
@@ -11,7 +9,7 @@ struct SearchPersonPickerView: View {
   @State private var showsResults = false
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "搜索人物") {
       ScrollView {
         VStack {
           if !showsResults {
@@ -27,8 +25,6 @@ struct SearchPersonPickerView: View {
           }
         }.padding()
       }
-      .navigationTitle("搜索人物")
-      .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索人物")
       .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
@@ -53,19 +49,9 @@ struct SearchPersonPickerView: View {
           }
         }
       }
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Image(systemName: remote ? "globe" : "internaldrive")
-            .foregroundColor(remote ? .blue : .green)
-        }
-      }
+    } controls: {
+      Image(systemName: remote ? "globe" : "internaldrive")
+        .foregroundColor(remote ? .blue : .green)
     }
   }
 }

--- a/App/Views/Discover/Search/SearchSubjectPickerView.swift
+++ b/App/Views/Discover/Search/SearchSubjectPickerView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct SearchSubjectPickerView: View {
-  @Environment(\.dismiss) var dismiss
-
   let onSelect: (Int) -> Void
 
   @State private var searchText: String = ""
@@ -12,7 +10,7 @@ struct SearchSubjectPickerView: View {
   @State private var showsResults = false
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "搜索条目") {
       ScrollView {
         VStack(spacing: 8) {
           Picker("Subject Type", selection: $subjectType.animated()) {
@@ -43,8 +41,6 @@ struct SearchSubjectPickerView: View {
           }
         }.padding()
       }
-      .navigationTitle("搜索条目")
-      .navigationBarTitleDisplayMode(.inline)
       .searchable(text: $searchText, isPresented: $searching, prompt: "搜索条目")
       .searchInputTraits()
       .searchPresentationToolbarBehavior(.avoidHidingContent)
@@ -69,19 +65,9 @@ struct SearchSubjectPickerView: View {
           }
         }
       }
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Image(systemName: remote ? "globe" : "internaldrive")
-            .foregroundColor(remote ? .blue : .green)
-        }
-      }
+    } controls: {
+      Image(systemName: remote ? "globe" : "internaldrive")
+        .foregroundColor(remote ? .blue : .green)
     }
   }
 }

--- a/App/Views/Index/IndexEditView.swift
+++ b/App/Views/Index/IndexEditView.swift
@@ -55,7 +55,11 @@ struct IndexEditSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(
+      title: indexId == nil ? "创建目录" : "编辑目录",
+      closeDisabled: isSubmitting,
+      applyFormStyle: true
+    ) {
       Form {
         Section {
           TextField("标题", text: $title)
@@ -81,28 +85,15 @@ struct IndexEditSheet: View {
           Text("隐私设置")
         }
       }
-      .navigationTitle(indexId == nil ? "创建目录" : "编辑目录")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(isSubmitting)
+    } controls: {
+      Button {
+        Task {
+          await submit()
         }
-        ToolbarItem(placement: .confirmationAction) {
-          Button {
-            Task {
-              await submit()
-            }
-          } label: {
-            Label("保存", systemImage: "checkmark")
-          }
-          .disabled(isSubmitting || title.isEmpty || desc.isEmpty)
-        }
+      } label: {
+        Label("保存", systemImage: "checkmark")
       }
+      .disabled(isSubmitting || title.isEmpty || desc.isEmpty)
     }
   }
 }

--- a/App/Views/Index/IndexRelatedEditView.swift
+++ b/App/Views/Index/IndexRelatedEditView.swift
@@ -47,7 +47,7 @@ struct IndexRelatedAddSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "添加关联内容", closeDisabled: isSubmitting, applyFormStyle: true) {
       Form {
         Section {
           Picker("类型", selection: $selectedCategory) {
@@ -95,28 +95,6 @@ struct IndexRelatedAddSheet: View {
           }
         }
       }
-      .navigationTitle("添加关联内容")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(isSubmitting)
-        }
-        ToolbarItem(placement: .confirmationAction) {
-          Button {
-            Task {
-              await submit()
-            }
-          } label: {
-            Label("添加", systemImage: "plus")
-          }
-          .disabled(isSubmitting || relatedId.isEmpty)
-        }
-      }
       .sheet(isPresented: $showSearch) {
         switch selectedCategory {
         case .subject:
@@ -135,6 +113,15 @@ struct IndexRelatedAddSheet: View {
           EmptyView()
         }
       }
+    } controls: {
+      Button {
+        Task {
+          await submit()
+        }
+      } label: {
+        Label("添加", systemImage: "plus")
+      }
+      .disabled(isSubmitting || relatedId.isEmpty)
     }
   }
 }
@@ -185,7 +172,7 @@ struct IndexRelatedEditSheet: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(title: "编辑关联内容", closeDisabled: isSubmitting, applyFormStyle: true) {
       Form {
         TextField("排序", text: $order)
           .keyboardType(.numberPad)
@@ -201,28 +188,15 @@ struct IndexRelatedEditSheet: View {
             }
           }
       }
-      .navigationTitle("编辑关联内容")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Label("取消", systemImage: "xmark")
-          }
-          .disabled(isSubmitting)
+    } controls: {
+      Button {
+        Task {
+          await submit()
         }
-        ToolbarItem(placement: .confirmationAction) {
-          Button {
-            Task {
-              await submit()
-            }
-          } label: {
-            Label("保存", systemImage: "checkmark")
-          }
-          .disabled(isSubmitting || order.isEmpty)
-        }
+      } label: {
+        Label("保存", systemImage: "checkmark")
       }
+      .disabled(isSubmitting || order.isEmpty)
     }
   }
 }

--- a/App/Views/Subject/SubjectBrowsingView.swift
+++ b/App/Views/Subject/SubjectBrowsingView.swift
@@ -380,7 +380,11 @@ struct SubjectBrowsingFilterView: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(
+      title: "筛选",
+      showsCloseButton: false,
+      controlsPlacement: .topBarTrailing
+    ) {
       ScrollView {
         VStack {
 
@@ -587,16 +591,11 @@ struct SubjectBrowsingFilterView: View {
 
         }.padding()
       }
-      .navigationTitle("筛选")
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .topBarTrailing) {
-          Button {
-            dismiss()
-          } label: {
-            Text("完成")
-          }
-        }
+    } controls: {
+      Button {
+        dismiss()
+      } label: {
+        Text("完成")
       }
     }
   }

--- a/App/Views/Subject/SubjectCollectionBoxView.swift
+++ b/App/Views/Subject/SubjectCollectionBoxView.swift
@@ -134,7 +134,12 @@ struct SubjectCollectionBoxView: View {
   }
 
   var body: some View {
-    NavigationStack {
+    SheetView(
+      title: subjectTitle,
+      size: .both,
+      closeDisabled: updating,
+      controlsPlacement: .primaryAction
+    ) {
       ScrollView {
         VStack {
           HStack {
@@ -268,32 +273,18 @@ struct SubjectCollectionBoxView: View {
         .disabled(updating)
         .padding(.horizontal)
       }
-      .navigationTitle(subjectTitle)
-      .navigationBarTitleDisplayMode(.inline)
-      .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
-          Button {
-            dismiss()
-          } label: {
-            Image(systemName: "xmark")
-          }
-          .disabled(updating)
-        }
-        ToolbarItem(placement: .primaryAction) {
-          Button {
-            withAnimation(.default) {
-              priv.toggle()
-            }
-          } label: {
-            Image(systemName: priv ? "lock.fill" : "lock.circle.dotted")
-          }
-          .adaptiveButtonStyle(priv ? .borderedProminent : .plain)
-          .disabled(updating)
-          .sensoryFeedback(.selection, trigger: priv)
-        }
-      }
       .task(load)
+    } controls: {
+      Button {
+        withAnimation(.default) {
+          priv.toggle()
+        }
+      } label: {
+        Image(systemName: priv ? "lock.fill" : "lock.circle.dotted")
+      }
+      .adaptiveButtonStyle(priv ? .borderedProminent : .plain)
+      .disabled(updating)
+      .sensoryFeedback(.selection, trigger: priv)
     }
-    .presentationDetents(.init([.medium, .large]))
   }
 }

--- a/App/Views/Subject/SubjectHeaderView.swift
+++ b/App/Views/Subject/SubjectHeaderView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SubjectHeaderView: View {
   let subject: SubjectDTO
+  let onShowRating: () -> Void
 
   var type: SubjectType {
     subject.type
@@ -98,14 +99,17 @@ struct SubjectHeaderView: View {
               Text("(\(subject.rating.total) 人评分)")
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-              Spacer()
             }
+            Spacer()
+            ratingDistributionButton
           }.font(.footnote)
         } else {
           HStack {
             StarsView(score: 0, size: 12)
             Text("(少于 10 人评分)")
               .foregroundStyle(.secondary)
+            Spacer()
+            ratingDistributionButton
           }.font(.footnote)
         }
       }
@@ -114,6 +118,18 @@ struct SubjectHeaderView: View {
     if subject.rating.rank > 0 && subject.rating.rank < 1000 {
       SubjectRankView(rank: subject.rating.rank)
     }
+  }
+
+  private var ratingDistributionButton: some View {
+    Button {
+      onShowRating()
+    } label: {
+      Image(systemName: "chart.bar.xaxis")
+    }
+    .buttonStyle(.borderless)
+    .font(.callout)
+    .foregroundStyle(.linkText)
+    .accessibilityLabel("评分分布")
   }
 }
 

--- a/App/Views/Subject/SubjectRatingView.swift
+++ b/App/Views/Subject/SubjectRatingView.swift
@@ -6,6 +6,16 @@ struct ScoreInfo {
   var offset: Int
 }
 
+struct SubjectRatingSheet: View {
+  var subject: SubjectDTO
+
+  var body: some View {
+    SheetView(title: "评分分布", size: .large, closeTitle: "关闭") {
+      SubjectRatingView(subject: subject)
+    }
+  }
+}
+
 struct SubjectRatingView: View {
   var subject: SubjectDTO
 
@@ -25,67 +35,72 @@ struct SubjectRatingView: View {
 
   var body: some View {
     ScrollView {
-      GeometryReader { geometry in
-        VStack(alignment: .leading) {
-          HStack {
-            MusumeView(index: scoreInfo.offset, width: 40, height: 55)
-            VStack(alignment: .leading) {
-              HStack(alignment: .center) {
-                Text("\(subject.rating.score.rateDisplay)").font(.title).foregroundStyle(.accent)
-                if subject.rating.score > 0 {
-                  Text(scoreInfo.desc)
-                }
-                Spacer()
-                BorderView {
-                  Text("\(subject.rating.total) 人评分")
-                    .font(.footnote)
-                }
+      VStack(alignment: .leading) {
+        HStack {
+          MusumeView(index: scoreInfo.offset, width: 40, height: 55)
+          VStack(alignment: .leading) {
+            HStack(alignment: .center) {
+              Text("\(subject.rating.score.rateDisplay)").font(.title).foregroundStyle(.accent)
+              if subject.rating.score > 0 {
+                Text(scoreInfo.desc)
               }
-              if subject.rating.rank > 0 {
-                HStack {
-                  Text("Bangumi \(subject.type.name.capitalized) Ranked:").foregroundStyle(
-                    .secondary)
-                  Text("#\(subject.rating.rank)")
-                }
+              Spacer()
+              BorderView {
+                Text("\(subject.rating.total) 人评分")
+                  .font(.footnote)
+              }
+            }
+            if subject.rating.rank > 0 {
+              HStack {
+                Text("Bangumi \(subject.type.name.capitalized) Ranked:").foregroundStyle(
+                  .secondary)
+                Text("#\(subject.rating.rank)")
               }
             }
           }
+        }
+        GeometryReader { geometry in
           ChartView(
-            title: "评分分布", data: chartData,
-            width: geometry.size.width, height: 320
+            title: "评分分布",
+            data: chartData,
+            width: geometry.size.width,
+            height: 320
           )
           .frame(width: geometry.size.width, height: 320)
           .background(Color.secondary.opacity(0.02))
           .clipShape(RoundedRectangle(cornerRadius: 10))
-          HFlow(alignment: .center, spacing: 2) {
-            Section {
-              Text("\(subject.collection.wish)人")
-              Text(CollectionType.wish.description(subject.type))
-            }
-            Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
-            Section {
-              Text("\(subject.collection.collect)人")
-              Text(CollectionType.collect.description(subject.type))
-            }
-            Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
-            Section {
-              Text("\(subject.collection.doing)人")
-              Text(CollectionType.doing.description(subject.type))
-            }
-            Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
-            Section {
-              Text("\(subject.collection.onHold)人")
-              Text(CollectionType.onHold.description(subject.type))
-            }
-            Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
-            Section {
-              Text("\(subject.collection.dropped)人")
-              Text(CollectionType.dropped.description(subject.type))
-            }
-          }.font(.footnote)
-          Spacer()
         }
-      }.padding()
+        .frame(height: 320)
+        HFlow(alignment: .center, spacing: 2) {
+          Section {
+            Text("\(subject.collection.wish)人")
+            Text(CollectionType.wish.description(subject.type))
+          }
+          Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
+          Section {
+            Text("\(subject.collection.collect)人")
+            Text(CollectionType.collect.description(subject.type))
+          }
+          Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
+          Section {
+            Text("\(subject.collection.doing)人")
+            Text(CollectionType.doing.description(subject.type))
+          }
+          Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
+          Section {
+            Text("\(subject.collection.onHold)人")
+            Text(CollectionType.onHold.description(subject.type))
+          }
+          Text("/").foregroundStyle(.secondary).padding(.horizontal, 2)
+          Section {
+            Text("\(subject.collection.dropped)人")
+            Text(CollectionType.dropped.description(subject.type))
+          }
+        }
+        .font(.footnote)
+        Spacer()
+      }
+      .padding()
     }
   }
 }

--- a/App/Views/Subject/SubjectView.swift
+++ b/App/Views/Subject/SubjectView.swift
@@ -95,6 +95,7 @@ struct SubjectDetailView: View {
 
   @State private var showCreateTopic: Bool = false
   @State private var showIndexPicker: Bool = false
+  @State private var showRatingSheet: Bool = false
 
   var shareLink: URL {
     URL(string: "\(shareDomain.url)/subject/\(subject.id)")!
@@ -103,7 +104,9 @@ struct SubjectDetailView: View {
   var body: some View {
     ScrollView(showsIndicators: false) {
       VStack(alignment: .leading) {
-        SubjectHeaderView(subject: subject)
+        SubjectHeaderView(subject: subject) {
+          showRatingSheet = true
+        }
 
         if isAuthenticated {
           SubjectCollectionView(subject: subject, reload: reload)
@@ -161,6 +164,9 @@ struct SubjectDetailView: View {
         itemTitle: subject.title(with: titlePreference)
       )
     }
+    .sheet(isPresented: $showRatingSheet) {
+      SubjectRatingSheet(subject: subject)
+    }
     .navigationTitle(subject.name)
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
@@ -168,9 +174,6 @@ struct SubjectDetailView: View {
         Menu {
           NavigationLink(value: NavDestination.subjectStaffList(subject.id)) {
             Label("制作人员", systemImage: "person.3")
-          }
-          NavigationLink(value: NavDestination.subjectRating(subject)) {
-            Label("评分分布", systemImage: "chart.bar.xaxis")
           }
           if isAuthenticated {
             Divider()

--- a/App/Views/Timeline/TimelineSayView.swift
+++ b/App/Views/Timeline/TimelineSayView.swift
@@ -22,37 +22,7 @@ struct TimelineSayView: View {
   }
 
   var body: some View {
-    VStack(spacing: 0) {
-      HStack {
-        Button {
-          dismiss()
-        } label: {
-          Label("取消", systemImage: "xmark")
-        }
-        .disabled(updating)
-        .adaptiveButtonStyle(.bordered)
-
-        Spacer()
-
-        Text("吐槽")
-          .font(.headline)
-          .fontWeight(.semibold)
-
-        Spacer()
-
-        Button {
-          showTurnstile = true
-        } label: {
-          Label("发送", systemImage: "paperplane")
-        }
-        .disabled(content.isEmpty || updating || content.count > 380)
-        .adaptiveButtonStyle(.borderedProminent)
-      }
-      .padding()
-      .background(Color(.systemBackground))
-
-      Divider()
-
+    SheetView(title: "吐槽", closeDisabled: updating) {
       ScrollView {
         VStack {
           TextInputView(type: "吐槽", text: $content)
@@ -68,6 +38,13 @@ struct TimelineSayView: View {
             }
         }.padding()
       }
+    } controls: {
+      Button {
+        showTurnstile = true
+      } label: {
+        Label("发送", systemImage: "paperplane")
+      }
+      .disabled(content.isEmpty || updating || content.count > 380)
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add a shared `SheetView` container for modal titles, close actions, optional toolbar controls, presentation detents, and form styling.
- Move existing SwiftUI sheet surfaces onto the shared container instead of repeating `NavigationStack` and toolbar chrome.
- Move subject rating distribution out of the toolbar menu into a link-colored rating-row icon that opens a large sheet.

## Validation

- `make build`
- `git diff --check`
