### PR TITLE
fix(subject): show collect status as avatar badge

### DIFF
--- a/App/Views/Subject/SubjectCollectsView.swift
+++ b/App/Views/Subject/SubjectCollectsView.swift
@@ -123,6 +123,7 @@ struct SubjectCollectsView: View {
             ForEach(collects.prefix(10)) { collect in
               VStack(spacing: 4) {
                 ImageView(img: collect.user.avatar?.large)
+                  .imageCollectionStatus(ctype: collect.interest.type)
                   .imageStyle(width: 60, height: 60)
                   .imageType(.avatar)
                   .contextMenu {
@@ -138,12 +139,6 @@ struct SubjectCollectsView: View {
                   Text(collect.user.nickname)
                     .lineLimit(1)
                   StarsView(score: Float(collect.interest.rate), size: 8)
-                  Label(
-                    collect.interest.type.description(subject.type),
-                    systemImage: collect.interest.type.icon
-                  )
-                  .labelStyle(.compact)
-                  .foregroundStyle(.secondary)
                 }
                 .font(.caption)
                 .frame(width: 60)


### PR DESCRIPTION
## Summary

Show each user's subject collection status in the subject detail collects section as the same lower-right image badge used elsewhere for subject collection status.

This removes the separate status row under each avatar, keeping the compact section focused on avatar, nickname, and rating while preserving the collection-state signal.

## Validation

- `git diff --check`
- `make build`
