### PR TITLE
feat(profile): add privacy settings page

### DIFF
--- a/App/Client/PrivacyService.swift
+++ b/App/Client/PrivacyService.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+enum ProfilePrivacyValue: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
+  case all
+  case friends
+  case none
+
+  var id: Self {
+    self
+  }
+
+  static var binaryValues: [Self] {
+    [.all, .none]
+  }
+}
+
+struct ProfilePrivacySettingsDTO: Codable, Equatable, Sendable {
+  var privateMessage: ProfilePrivacyValue
+  var timelineReply: ProfilePrivacyValue
+  var timelineCollectReply: ProfilePrivacyValue
+  var follow: ProfilePrivacyValue
+  var mentionNotification: ProfilePrivacyValue
+  var commentNotification: ProfilePrivacyValue
+  var friendNotification: ProfilePrivacyValue
+
+  init(
+    privateMessage: ProfilePrivacyValue = .all,
+    timelineReply: ProfilePrivacyValue = .all,
+    timelineCollectReply: ProfilePrivacyValue = .friends,
+    follow: ProfilePrivacyValue = .all,
+    mentionNotification: ProfilePrivacyValue = .all,
+    commentNotification: ProfilePrivacyValue = .all,
+    friendNotification: ProfilePrivacyValue = .all
+  ) {
+    self.privateMessage = privateMessage
+    self.timelineReply = timelineReply
+    self.timelineCollectReply = timelineCollectReply
+    self.follow = follow
+    self.mentionNotification = mentionNotification
+    self.commentNotification = commentNotification
+    self.friendNotification = friendNotification
+  }
+}
+
+struct ProfilePrivacyPreferencesDTO: Codable, Equatable, Sendable {
+  var showNsfwSubject: Bool
+  var canSetNsfwSubject: Bool
+  var allowNsfw: Bool
+}
+
+struct ProfilePrivacyDTO: Codable, Equatable, Sendable {
+  var settings: ProfilePrivacySettingsDTO
+  var preferences: ProfilePrivacyPreferencesDTO
+}
+
+enum PrivacyService {
+  static func getProfilePrivacy() async throws -> ProfilePrivacyDTO {
+    let url = BangumiAPI.priv.build("p1/privacy")
+    let data = try await APIClient.shared.request(url: url, method: "GET", auth: .required)
+    let resp: ProfilePrivacyDTO = try await APIClient.shared.decodeResponse(data)
+    return resp
+  }
+
+  static func updateProfilePrivacy(
+    settings: ProfilePrivacySettingsDTO,
+    showNsfwSubject: Bool?
+  ) async throws -> ProfilePrivacyDTO {
+    let url = BangumiAPI.priv.build("p1/privacy")
+    var body: [String: Any] = [
+      "settings": [
+        "privateMessage": settings.privateMessage.rawValue,
+        "timelineReply": settings.timelineReply.rawValue,
+        "timelineCollectReply": settings.timelineCollectReply.rawValue,
+        "follow": settings.follow.rawValue,
+        "mentionNotification": settings.mentionNotification.rawValue,
+        "commentNotification": settings.commentNotification.rawValue,
+        "friendNotification": settings.friendNotification.rawValue,
+      ]
+    ]
+    if let showNsfwSubject {
+      body["preferences"] = [
+        "showNsfwSubject": showNsfwSubject
+      ]
+    }
+
+    let data = try await APIClient.shared.request(
+      url: url,
+      method: "PATCH",
+      body: body,
+      auth: .required
+    )
+    let resp: ProfilePrivacyDTO = try await APIClient.shared.decodeResponse(data)
+    return resp
+  }
+}

--- a/App/Helpers/Navigation.swift
+++ b/App/Helpers/Navigation.swift
@@ -19,6 +19,7 @@ enum NavDestination: Hashable, View {
   case calendar
   case collectionList(_ subjectType: SubjectType)
   case export
+  case profilePrivacy
 
   case user(_ username: String)
   case userCollection(_ user: SlimUserDTO, _ stype: SubjectType, _ ctypes: [CollectionType: Int])
@@ -86,6 +87,8 @@ enum NavDestination: Hashable, View {
       CollectionListView(subjectType: subjectType)
     case .export:
       ExportView()
+    case .profilePrivacy:
+      ProfilePrivacyView()
 
     case .user(let username):
       UserView(username: username)

--- a/App/Views/MainView.swift
+++ b/App/Views/MainView.swift
@@ -68,7 +68,7 @@ struct MainView: View {
         Tab(ChiiViewTab.me.title, systemImage: ChiiViewTab.me.icon, value: .me) {
           ZoomTransitionContainer {
             NavigationStack(path: $meNav) {
-              CollectionsView()
+              ProfileHomeView()
                 .navigationDestination(for: NavDestination.self) { $0 }
             }
           }

--- a/App/Views/OldTabView.swift
+++ b/App/Views/OldTabView.swift
@@ -65,7 +65,7 @@ struct OldTabView: View {
 
       if isAuthenticated {
         NavigationStack(path: $meNav) {
-          CollectionsView()
+          ProfileHomeView()
             .navigationDestination(for: NavDestination.self) { $0 }
         }
         .tag(ChiiViewTab.me)

--- a/App/Views/Profile/ProfileHomeView.swift
+++ b/App/Views/Profile/ProfileHomeView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct CollectionsView: View {
+struct ProfileHomeView: View {
   @AppStorage("profile") var profile: Profile = Profile()
 
   var body: some View {
@@ -22,6 +22,10 @@ struct CollectionsView: View {
     .toolbar {
       ToolbarItem(placement: .topBarTrailing) {
         Menu {
+          NavigationLink(value: NavDestination.profilePrivacy) {
+            Label("隐私设置", systemImage: "hand.raised")
+          }
+
           NavigationLink(value: NavDestination.export) {
             Label("导出收藏", systemImage: "square.and.arrow.up")
           }

--- a/App/Views/Profile/ProfilePrivacyView.swift
+++ b/App/Views/Profile/ProfilePrivacyView.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+
+struct ProfilePrivacyView: View {
+  @State private var privacy: ProfilePrivacyDTO?
+  @State private var draftSettings = ProfilePrivacySettingsDTO()
+  @State private var showNsfwSubject = false
+  @State private var isLoading = false
+  @State private var isSaving = false
+
+  private var isBusy: Bool {
+    isLoading || isSaving
+  }
+
+  private var hasChanges: Bool {
+    guard let privacy else {
+      return false
+    }
+    return draftSettings != privacy.settings
+      || showNsfwSubject != privacy.preferences.showNsfwSubject
+  }
+
+  var body: some View {
+    Form {
+      if let privacy {
+        ProfilePrivacyInteractionSection(
+          settings: $draftSettings,
+          disabled: isBusy
+        )
+        ProfilePrivacyNotificationSection(
+          settings: $draftSettings,
+          disabled: isBusy
+        )
+        if privacy.preferences.canSetNsfwSubject {
+          ProfilePrivacyPreferenceSection(
+            preferences: privacy.preferences,
+            showNsfwSubject: $showNsfwSubject,
+            disabled: isBusy
+          )
+        }
+      } else {
+        ProfilePrivacyLoadingSection()
+      }
+    }
+    .disabled(isBusy)
+    .navigationTitle("隐私设置")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .topBarTrailing) {
+        Button(isSaving ? "保存中" : "保存") {
+          Task {
+            await save()
+          }
+        }
+        .disabled(!hasChanges || isBusy)
+      }
+    }
+    .refreshable {
+      await load()
+    }
+    .task {
+      await load()
+    }
+  }
+
+  private func load() async {
+    if isLoading {
+      return
+    }
+    isLoading = true
+    defer {
+      isLoading = false
+    }
+
+    do {
+      let fetched = try await PrivacyService.getProfilePrivacy()
+      withAnimation(.default) {
+        privacy = fetched
+        draftSettings = fetched.settings
+        showNsfwSubject = fetched.preferences.showNsfwSubject
+      }
+    } catch {
+      Notifier.shared.alert(error: error)
+    }
+  }
+
+  private func save() async {
+    guard let privacy, hasChanges else {
+      return
+    }
+    isSaving = true
+    defer {
+      isSaving = false
+    }
+
+    do {
+      let updated = try await PrivacyService.updateProfilePrivacy(
+        settings: draftSettings,
+        showNsfwSubject: privacy.preferences.canSetNsfwSubject ? showNsfwSubject : nil
+      )
+      withAnimation(.default) {
+        self.privacy = updated
+        draftSettings = updated.settings
+        showNsfwSubject = updated.preferences.showNsfwSubject
+      }
+      Notifier.shared.notify(message: "隐私设置已更新")
+    } catch {
+      Notifier.shared.alert(error: error)
+    }
+  }
+}
+
+private struct ProfilePrivacyInteractionSection: View {
+  @Binding var settings: ProfilePrivacySettingsDTO
+  let disabled: Bool
+
+  var body: some View {
+    Section {
+      ProfilePrivacyValuePicker(
+        title: "发送短信",
+        description: "谁可以向你发送站内短信",
+        selection: $settings.privateMessage,
+        values: ProfilePrivacyValue.allCases
+      )
+      ProfilePrivacyValuePicker(
+        title: "回复时间线吐槽",
+        description: "谁可以回复你的时间线吐槽",
+        selection: $settings.timelineReply,
+        values: ProfilePrivacyValue.allCases
+      )
+      ProfilePrivacyValuePicker(
+        title: "回复时间线收藏",
+        description: "谁可以回复你的时间线收藏动态",
+        selection: $settings.timelineCollectReply,
+        values: ProfilePrivacyValue.allCases
+      )
+      ProfilePrivacyValuePicker(
+        title: "加我好友",
+        description: "是否允许其他用户向你发送好友请求",
+        selection: $settings.follow,
+        values: ProfilePrivacyValue.binaryValues
+      )
+    } header: {
+      Text("谁可以")
+    }
+    .disabled(disabled)
+  }
+}
+
+private struct ProfilePrivacyNotificationSection: View {
+  @Binding var settings: ProfilePrivacySettingsDTO
+  let disabled: Bool
+
+  var body: some View {
+    Section {
+      ProfilePrivacyValuePicker(
+        title: "@ 提醒",
+        description: "谁的 @ 提醒会发送给你",
+        selection: $settings.mentionNotification,
+        values: ProfilePrivacyValue.allCases
+      )
+      ProfilePrivacyValuePicker(
+        title: "评论提醒",
+        description: "谁的评论回复会发送提醒",
+        selection: $settings.commentNotification,
+        values: ProfilePrivacyValue.allCases
+      )
+      ProfilePrivacyValuePicker(
+        title: "加好友提醒",
+        description: "是否接收好友请求相关提醒",
+        selection: $settings.friendNotification,
+        values: ProfilePrivacyValue.binaryValues
+      )
+    } header: {
+      Text("提醒")
+    }
+    .disabled(disabled)
+  }
+}
+
+private struct ProfilePrivacyPreferenceSection: View {
+  let preferences: ProfilePrivacyPreferencesDTO
+  @Binding var showNsfwSubject: Bool
+  let disabled: Bool
+
+  private var statusText: LocalizedStringKey {
+    preferences.allowNsfw ? "已启用" : "未启用"
+  }
+
+  var body: some View {
+    Section {
+      Toggle(isOn: $showNsfwSubject) {
+        SettingLabel("显示 NSFW 条目", description: "允许搜索、浏览和推荐展示已标记为 NSFW 的条目")
+      }
+      .disabled(disabled)
+
+      HStack {
+        Text("当前状态")
+        Spacer()
+        Text(statusText)
+          .foregroundStyle(.secondary)
+      }
+
+    } header: {
+      Text("内容偏好")
+    }
+  }
+}
+
+private struct ProfilePrivacyValuePicker: View {
+  let title: LocalizedStringKey
+  let description: LocalizedStringKey
+  @Binding var selection: ProfilePrivacyValue
+  let values: [ProfilePrivacyValue]
+
+  var body: some View {
+    Picker(selection: $selection) {
+      ForEach(values) { value in
+        Text(value.label).tag(value)
+      }
+    } label: {
+      SettingLabel(title, description: description)
+    }
+  }
+}
+
+private struct ProfilePrivacyLoadingSection: View {
+  var body: some View {
+    Section {
+      HStack {
+        Spacer()
+        ProgressView()
+        Spacer()
+      }
+    }
+  }
+}
+
+private extension ProfilePrivacyValue {
+  var label: LocalizedStringKey {
+    switch self {
+    case .all:
+      return "所有人"
+    case .friends:
+      return "我的好友"
+    case .none:
+      return "不接收"
+    }
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7257,6 +7257,267 @@ paths:
       summary: 获取人物的参与作品
       tags:
         - person
+  /p1/privacy:
+    get:
+      operationId: getPrivacy
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Get current user privacy settings
+      tags:
+        - user
+    patch:
+      operationId: patchPrivacy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: false
+              properties:
+                preferences:
+                  additionalProperties: false
+                  properties:
+                    showNsfwSubject:
+                      type: boolean
+                  type: object
+                settings:
+                  additionalProperties: false
+                  properties:
+                    commentNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    follow:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    friendNotification:
+                      enum:
+                        - all
+                        - none
+                      type: string
+                    mentionNotification:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    privateMessage:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineCollectReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                    timelineReply:
+                      enum:
+                        - all
+                        - friends
+                        - none
+                      type: string
+                  type: object
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  preferences:
+                    properties:
+                      allowNsfw:
+                        type: boolean
+                      canSetNsfwSubject:
+                        type: boolean
+                      showNsfwSubject:
+                        type: boolean
+                    required:
+                      - showNsfwSubject
+                      - canSetNsfwSubject
+                      - allowNsfw
+                    type: object
+                  settings:
+                    properties:
+                      commentNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      follow:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      friendNotification:
+                        enum:
+                          - all
+                          - none
+                        type: string
+                      mentionNotification:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      privateMessage:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineCollectReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                      timelineReply:
+                        enum:
+                          - all
+                          - friends
+                          - none
+                        type: string
+                    required:
+                      - privateMessage
+                      - timelineReply
+                      - timelineCollectReply
+                      - follow
+                      - mentionNotification
+                      - commentNotification
+                      - friendNotification
+                    type: object
+                required:
+                  - settings
+                  - preferences
+                type: object
+          description: Default Response
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: default error response type
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: 意料之外的服务器错误
+      security:
+        - CookiesSession: []
+          HTTPBearer: []
+      summary: Update current user privacy settings
+      tags:
+        - user
   /p1/report:
     post:
       operationId: createReport


### PR DESCRIPTION
## Summary

Adds a profile privacy settings screen under the My tab toolbar menu, backed by the new `GET /p1/privacy` and `PATCH /p1/privacy` API. The screen lets users review and update interaction privacy, notification privacy, and the NSFW subject preference when the server says that preference is available.

This also renames the My tab root view from `CollectionsView` to `ProfileHomeView`, since the screen now owns profile-level actions in addition to the collection overview.

## Validation

- `git diff --check`
- `make build`
