### PR TITLE
feat(settings): support custom Bangumi domains

### DIFF
--- a/App/Client/AccountService.swift
+++ b/App/Client/AccountService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum AccountService {
   static func getProfile() async throws -> Profile {
-    let url = BangumiAPI.priv.build("p1/me")
+    let url = BangumiURL.next(path: "p1/me")
     let data = try await APIClient.shared.request(url: url, method: "GET", auth: .required)
     guard let rawValue = String(data: data, encoding: .utf8) else {
       throw ChiiError.request("profile data error")
@@ -11,14 +11,14 @@ enum AccountService {
   }
 
   static func getFriendList() async throws -> [Int] {
-    let url = BangumiAPI.priv.build("p1/friendlist")
+    let url = BangumiURL.next(path: "p1/friendlist")
     let data = try await APIClient.shared.request(url: url, method: "GET", auth: .required)
     let resp: FriendListResponseDTO = try await APIClient.shared.decodeResponse(data)
     return resp.friendlist
   }
 
   static func getBlockList() async throws -> [Int] {
-    let url = BangumiAPI.priv.build("p1/blocklist")
+    let url = BangumiURL.next(path: "p1/blocklist")
     let data = try await APIClient.shared.request(url: url, method: "GET", auth: .required)
     let resp: BlockListResponseDTO = try await APIClient.shared.decodeResponse(data)
     return resp.blocklist
@@ -27,7 +27,7 @@ enum AccountService {
   static func listNotice(limit: Int? = nil, unread: Bool? = nil) async throws
     -> PagedDTO<NoticeDTO>
   {
-    let url = BangumiAPI.priv.build("p1/notify")
+    let url = BangumiURL.next(path: "p1/notify")
     var queryItems: [URLQueryItem] = []
     if let limit {
       queryItems.append(URLQueryItem(name: "limit", value: String(limit)))
@@ -42,19 +42,19 @@ enum AccountService {
   }
 
   static func clearNotice(ids: [Int]) async throws {
-    let url = BangumiAPI.priv.build("p1/clear-notify")
+    let url = BangumiURL.next(path: "p1/clear-notify")
     let body: [String: Any] = ["id": ids]
     _ = try await APIClient.shared.request(url: url, method: "POST", body: body, auth: .required)
   }
 
   static func like(path: String, value: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/\(path)/like")
+    let url = BangumiURL.next(path: "p1/\(path)/like")
     let body: [String: Any] = ["value": value]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func unlike(path: String) async throws {
-    let url = BangumiAPI.priv.build("p1/\(path)/like")
+    let url = BangumiURL.next(path: "p1/\(path)/like")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }
@@ -62,7 +62,7 @@ enum AccountService {
   static func createReport(type: ReportType, id: Int, reason: ReportReason, comment: String?)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/report")
+    let url = BangumiURL.next(path: "p1/report")
     var body: [String: Any] = [
       "type": type.rawValue,
       "id": id,

--- a/App/Client/AppConfig.swift
+++ b/App/Client/AppConfig.swift
@@ -39,6 +39,11 @@ enum AppConfig {
     set { UserDefaults.standard.set(newValue, forKey: "userAgent") }
   }
 
+  static nonisolated var mirrorRootDomain: String {
+    get { UserDefaults.standard.string(forKey: "mirrorRootDomain") ?? "" }
+    set { UserDefaults.standard.set(newValue, forKey: "mirrorRootDomain") }
+  }
+
   static nonisolated var subjectCollectsFilterMode: FilterMode {
     get { FilterMode(UserDefaults.standard.string(forKey: "subjectCollectsFilterMode")) }
     set { UserDefaults.standard.set(newValue.rawValue, forKey: "subjectCollectsFilterMode") }

--- a/App/Client/Auth.swift
+++ b/App/Client/Auth.swift
@@ -3,7 +3,7 @@ import OSLog
 
 extension APIClient {
   func getOAuthBase() -> String {
-    return "https://\(AppConfig.authDomain.rawValue)/oauth"
+    return BangumiURL.auth(path: "/oauth").absoluteString
   }
 
   func buildOAuthURL() -> URL {

--- a/App/Client/BangumiURL.swift
+++ b/App/Client/BangumiURL.swift
@@ -6,6 +6,14 @@ enum BangumiURL {
     BangumiDomains(mirrorRootDomain: mirrorRootDomain)
   }
 
+  static nonisolated func domains(mirrorRootDomain: String?) -> BangumiDomains {
+    BangumiDomains(mirrorRootDomain: mirrorRootDomain)
+  }
+
+  static nonisolated func normalizedMirrorRootDomain(_ rawValue: String?) -> String? {
+    BangumiDomains.normalizedRootDomain(rawValue)
+  }
+
   static nonisolated func main(path: String = "") -> URL {
     domains.mainURL(path: path)
   }
@@ -24,6 +32,33 @@ enum BangumiURL {
       return main(path: path)
     case .next:
       return next(path: path)
+    }
+  }
+
+  static nonisolated func authHost(for authDomain: AuthDomain) -> String {
+    switch authDomain {
+    case .origin:
+      domains.main
+    case .next:
+      domains.next
+    }
+  }
+
+  static nonisolated func shareRootURL(for shareDomain: ShareDomain) -> URL {
+    switch shareDomain {
+    case .mirror:
+      domains.mainURL()
+    default:
+      URL(string: "https://\(shareDomain.rawValue)")!
+    }
+  }
+
+  static nonisolated func shareHost(for shareDomain: ShareDomain) -> String {
+    switch shareDomain {
+    case .mirror:
+      domains.main
+    default:
+      shareDomain.rawValue
     }
   }
 

--- a/App/Client/BangumiURL.swift
+++ b/App/Client/BangumiURL.swift
@@ -1,0 +1,44 @@
+import BBCode
+import Foundation
+
+enum BangumiURL {
+  static nonisolated var domains: BangumiDomains {
+    BangumiDomains(mirrorRootDomain: mirrorRootDomain)
+  }
+
+  static nonisolated func main(path: String = "") -> URL {
+    domains.mainURL(path: path)
+  }
+
+  static nonisolated func image(path: String = "") -> URL {
+    domains.imageURL(path: path)
+  }
+
+  static nonisolated func next(path: String = "") -> URL {
+    domains.nextURL(path: path)
+  }
+
+  static nonisolated func auth(path: String = "") -> URL {
+    switch AppConfig.authDomain {
+    case .origin:
+      return main(path: path)
+    case .next:
+      return next(path: path)
+    }
+  }
+
+  static nonisolated func imageURLString(from rawValue: String) -> String {
+    guard var components = URLComponents(string: rawValue),
+      components.host == CDN_DOMAIN
+    else {
+      return rawValue
+    }
+
+    components.host = domains.image
+    return components.url?.absoluteString ?? rawValue
+  }
+
+  private static nonisolated var mirrorRootDomain: String {
+    AppConfig.mirrorRootDomain
+  }
+}

--- a/App/Client/Basis.swift
+++ b/App/Client/Basis.swift
@@ -93,7 +93,8 @@ struct SubjectImages: Codable, Hashable {
 
   func resize(_ size: ImageSize) -> String {
     guard let url = URL(string: large) else { return "" }
-    return "\(url.scheme ?? HTTPS)://\(url.host ?? CDN_DOMAIN)/r/\(size.rawValue)\(url.path)"
+    let host = url.host == CDN_DOMAIN ? BangumiURL.domains.image : (url.host ?? CDN_DOMAIN)
+    return "\(url.scheme ?? HTTPS)://\(host)/r/\(size.rawValue)\(url.path)"
   }
 }
 
@@ -105,7 +106,8 @@ struct Images: Codable, Hashable {
 
   func resize(_ size: ImageSize) -> String {
     guard let url = URL(string: large) else { return "" }
-    return "\(url.scheme ?? HTTPS)://\(url.host ?? CDN_DOMAIN)/r/\(size.rawValue)\(url.path)"
+    let host = url.host == CDN_DOMAIN ? BangumiURL.domains.image : (url.host ?? CDN_DOMAIN)
+    return "\(url.scheme ?? HTTPS)://\(host)/r/\(size.rawValue)\(url.path)"
   }
 }
 

--- a/App/Client/BlogService.swift
+++ b/App/Client/BlogService.swift
@@ -2,21 +2,21 @@ import Foundation
 
 enum BlogService {
   static func getBlogEntry(_ entryId: Int) async throws -> BlogEntryDTO {
-    let url = BangumiAPI.priv.build("p1/blogs/\(entryId)")
+    let url = BangumiURL.next(path: "p1/blogs/\(entryId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let blog: BlogEntryDTO = try await APIClient.shared.decodeResponse(data)
     return blog
   }
 
   static func getBlogSubjects(_ entryId: Int) async throws -> [SlimSubjectDTO] {
-    let url = BangumiAPI.priv.build("p1/blogs/\(entryId)/subjects")
+    let url = BangumiURL.next(path: "p1/blogs/\(entryId)/subjects")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let subjects: [SlimSubjectDTO] = try await APIClient.shared.decodeResponse(data)
     return subjects
   }
 
   static func getBlogComments(_ entryId: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/blogs/\(entryId)/comments")
+    let url = BangumiURL.next(path: "p1/blogs/\(entryId)/comments")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -25,7 +25,7 @@ enum BlogService {
   static func createBlogComment(blogId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/blogs/\(blogId)/comments")
+    let url = BangumiURL.next(path: "p1/blogs/\(blogId)/comments")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,

--- a/App/Client/CharacterService.swift
+++ b/App/Client/CharacterService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum CharacterService {
   static func getCharacter(_ characterId: Int) async throws -> CharacterDTO {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let character: CharacterDTO = try await APIClient.shared.decodeResponse(data)
     return character
@@ -12,7 +12,7 @@ enum CharacterService {
     _ characterId: Int, type: CastType = .none, subjectType: SubjectType = .none, limit: Int = 20,
     offset: Int = 0
   ) async throws -> PagedDTO<CharacterCastDTO> {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/casts")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/casts")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -32,7 +32,7 @@ enum CharacterService {
   static func getCharacterRelations(_ characterId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<CharacterRelationDTO>
   {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/relations")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/relations")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -46,7 +46,7 @@ enum CharacterService {
   static func getCharacterCollects(_ characterId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<PersonCollectDTO>
   {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/collects")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/collects")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -60,7 +60,7 @@ enum CharacterService {
   static func getCharacterIndexes(characterId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<SlimIndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/indexes")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/indexes")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -72,7 +72,7 @@ enum CharacterService {
   }
 
   static func getCharacterComments(_ characterId: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/comments")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/comments")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -83,7 +83,7 @@ enum CharacterService {
   )
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/characters/\(characterId)/comments")
+    let url = BangumiURL.next(path: "p1/characters/\(characterId)/comments")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,
@@ -95,13 +95,13 @@ enum CharacterService {
   }
 
   static func collectCharacter(_ characterId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/characters/\(characterId)")
+    let url = BangumiURL.next(path: "p1/collections/characters/\(characterId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func uncollectCharacter(_ characterId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/characters/\(characterId)")
+    let url = BangumiURL.next(path: "p1/collections/characters/\(characterId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }

--- a/App/Client/CollectionService.swift
+++ b/App/Client/CollectionService.swift
@@ -4,7 +4,7 @@ enum CollectionService {
   static func getCharacterCollections(limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<CharacterDTO>
   {
-    let url = BangumiAPI.priv.build("p1/collections/characters")
+    let url = BangumiURL.next(path: "p1/collections/characters")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET",
@@ -16,7 +16,7 @@ enum CollectionService {
   static func getIndexCollections(limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<IndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/collections/indexes")
+    let url = BangumiURL.next(path: "p1/collections/indexes")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET",
@@ -28,7 +28,7 @@ enum CollectionService {
   static func getPersonCollections(limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<PersonDTO>
   {
-    let url = BangumiAPI.priv.build("p1/collections/persons")
+    let url = BangumiURL.next(path: "p1/collections/persons")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET",
@@ -44,7 +44,7 @@ enum CollectionService {
     limit: Int = 100,
     offset: Int = 0
   ) async throws -> PagedDTO<SubjectDTO> {
-    let url = BangumiAPI.priv.build("p1/collections/subjects")
+    let url = BangumiURL.next(path: "p1/collections/subjects")
     var queryItems = [
       URLQueryItem(name: "since", value: String(since)),
       URLQueryItem(name: "limit", value: String(limit)),

--- a/App/Client/CommentService.swift
+++ b/App/Client/CommentService.swift
@@ -44,17 +44,17 @@ enum CommentService {
   private static func commentURL(type: CommentParentType, commentId: Int) -> URL {
     switch type {
     case .blog:
-      BangumiAPI.priv.build("p1/blogs/-/comments/\(commentId)")
+      BangumiURL.next(path: "p1/blogs/-/comments/\(commentId)")
     case .character:
-      BangumiAPI.priv.build("p1/characters/-/comments/\(commentId)")
+      BangumiURL.next(path: "p1/characters/-/comments/\(commentId)")
     case .person:
-      BangumiAPI.priv.build("p1/persons/-/comments/\(commentId)")
+      BangumiURL.next(path: "p1/persons/-/comments/\(commentId)")
     case .episode:
-      BangumiAPI.priv.build("p1/episodes/-/comments/\(commentId)")
+      BangumiURL.next(path: "p1/episodes/-/comments/\(commentId)")
     case .timeline:
-      BangumiAPI.priv.build("p1/timeline/\(commentId)")
+      BangumiURL.next(path: "p1/timeline/\(commentId)")
     case .index:
-      BangumiAPI.priv.build("p1/indexes/-/comments/\(commentId)")
+      BangumiURL.next(path: "p1/indexes/-/comments/\(commentId)")
     }
   }
 }

--- a/App/Client/Core.swift
+++ b/App/Client/Core.swift
@@ -4,24 +4,6 @@ import OSLog
 
 let APP_DOMAIN = "com.everpcpc.chobits"
 
-enum BangumiAPI {
-  case pub
-  case priv
-
-  var endpoint: URL {
-    switch self {
-    case .pub:
-      return URL(string: "https://api.bgm.tv")!
-    case .priv:
-      return URL(string: "https://next.bgm.tv")!
-    }
-  }
-
-  func build(_ path: String) -> URL {
-    return self.endpoint.appendingPathComponent(path)
-  }
-}
-
 enum AuthMode {
   case auto
   case disabled

--- a/App/Client/DiscoveryService.swift
+++ b/App/Client/DiscoveryService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum DiscoveryService {
   static func getCalendar() async throws -> BangumiCalendarDTO {
-    let url = BangumiAPI.priv.build("p1/calendar")
+    let url = BangumiURL.next(path: "p1/calendar")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let calendars: BangumiCalendarDTO = try await APIClient.shared.decodeResponse(data)
     return calendars
@@ -11,7 +11,7 @@ enum DiscoveryService {
   static func getTrendingSubjects(
     type: SubjectType, limit: Int = 12, offset: Int = 0
   ) async throws -> PagedDTO<TrendingSubjectDTO> {
-    let url = BangumiAPI.priv.build("p1/trending/subjects")
+    let url = BangumiURL.next(path: "p1/trending/subjects")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "type", value: String(type.rawValue)),
       URLQueryItem(name: "limit", value: String(limit)),

--- a/App/Client/EpisodeService.swift
+++ b/App/Client/EpisodeService.swift
@@ -2,14 +2,14 @@ import Foundation
 
 enum EpisodeService {
   static func getEpisode(_ episodeId: Int) async throws -> EpisodeDTO {
-    let url = BangumiAPI.priv.build("p1/episodes/\(episodeId)")
+    let url = BangumiURL.next(path: "p1/episodes/\(episodeId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let episode: EpisodeDTO = try await APIClient.shared.decodeResponse(data)
     return episode
   }
 
   static func getEpisodeComments(_ episodeId: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/episodes/\(episodeId)/comments")
+    let url = BangumiURL.next(path: "p1/episodes/\(episodeId)/comments")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -18,7 +18,7 @@ enum EpisodeService {
   static func createEpisodeComment(episodeId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/episodes/\(episodeId)/comments")
+    let url = BangumiURL.next(path: "p1/episodes/\(episodeId)/comments")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,
@@ -32,7 +32,7 @@ enum EpisodeService {
   static func updateEpisodeCollection(
     episodeId: Int, type: EpisodeCollectionType, batch: Bool = false
   ) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/episodes/\(episodeId)")
+    let url = BangumiURL.next(path: "p1/collections/episodes/\(episodeId)")
     var body: [String: Any] = [:]
     if batch {
       body["batch"] = true

--- a/App/Client/FriendService.swift
+++ b/App/Client/FriendService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum FriendService {
   static func getFollowers(limit: Int = 20, offset: Int = 0) async throws -> PagedDTO<FriendDTO> {
-    let url = BangumiAPI.priv.build("p1/followers")
+    let url = BangumiURL.next(path: "p1/followers")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -11,7 +11,7 @@ enum FriendService {
   }
 
   static func getFriends(limit: Int = 20, offset: Int = 0) async throws -> PagedDTO<FriendDTO> {
-    let url = BangumiAPI.priv.build("p1/friends")
+    let url = BangumiURL.next(path: "p1/friends")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -20,25 +20,25 @@ enum FriendService {
   }
 
   static func addFriend(_ username: String) async throws {
-    let url = BangumiAPI.priv.build("p1/friends/\(username)")
+    let url = BangumiURL.next(path: "p1/friends/\(username)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func removeFriend(_ username: String) async throws {
-    let url = BangumiAPI.priv.build("p1/friends/\(username)")
+    let url = BangumiURL.next(path: "p1/friends/\(username)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }
 
   static func blockUser(_ username: String) async throws {
-    let url = BangumiAPI.priv.build("p1/blocklist/\(username)")
+    let url = BangumiURL.next(path: "p1/blocklist/\(username)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func unblockUser(_ username: String) async throws {
-    let url = BangumiAPI.priv.build("p1/blocklist/\(username)")
+    let url = BangumiURL.next(path: "p1/blocklist/\(username)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }

--- a/App/Client/GroupService.swift
+++ b/App/Client/GroupService.swift
@@ -5,7 +5,7 @@ enum GroupService {
     mode: GroupFilterMode = .all, sort: GroupSortMode = .created,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<SlimGroupDTO> {
-    let url = BangumiAPI.priv.build("p1/groups")
+    let url = BangumiURL.next(path: "p1/groups")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "mode", value: mode.rawValue),
       URLQueryItem(name: "sort", value: sort.rawValue),
@@ -19,7 +19,7 @@ enum GroupService {
   }
 
   static func getGroup(_ groupName: String) async throws -> GroupDTO {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: GroupDTO = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -29,7 +29,7 @@ enum GroupService {
     _ groupName: String, role: GroupMemberRole? = nil,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<GroupMemberDTO> {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)/members")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)/members")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -46,7 +46,7 @@ enum GroupService {
   static func getGroupTopics(_ groupName: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<TopicDTO>
   {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)/topics")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)/topics")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -58,13 +58,13 @@ enum GroupService {
   }
 
   static func joinGroup(_ groupName: String) async throws {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)/join")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)/join")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "POST", body: body, auth: .required)
   }
 
   static func leaveGroup(_ groupName: String) async throws {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)/leave")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)/leave")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "POST", body: body, auth: .required)
   }

--- a/App/Client/IndexService.swift
+++ b/App/Client/IndexService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum IndexService {
   static func getIndex(_ indexId: Int) async throws -> IndexDTO {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: IndexDTO = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -11,7 +11,7 @@ enum IndexService {
   static func createIndex(title: String, desc: String, private isPrivate: Bool = false)
     async throws -> Int
   {
-    let url = BangumiAPI.priv.build("p1/indexes")
+    let url = BangumiURL.next(path: "p1/indexes")
     let body: [String: Any] = [
       "title": title,
       "desc": desc,
@@ -25,7 +25,7 @@ enum IndexService {
   static func updateIndex(
     indexId: Int, title: String? = nil, desc: String? = nil, private isPrivate: Bool? = nil
   ) async throws {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)")
     var body: [String: Any] = [:]
     if let title {
       body["title"] = title
@@ -40,19 +40,19 @@ enum IndexService {
   }
 
   static func deleteIndex(indexId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body)
   }
 
   static func collectIndex(_ indexId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/indexes/\(indexId)")
+    let url = BangumiURL.next(path: "p1/collections/indexes/\(indexId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func uncollectIndex(_ indexId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/indexes/\(indexId)")
+    let url = BangumiURL.next(path: "p1/collections/indexes/\(indexId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }
@@ -61,7 +61,7 @@ enum IndexService {
     indexId: Int, cat: IndexRelatedCategory? = nil, type: SubjectType? = nil,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<IndexRelatedDTO> {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/related")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/related")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -82,7 +82,7 @@ enum IndexService {
     indexId: Int, cat: IndexRelatedCategory, sid: Int, order: Int? = nil,
     comment: String? = nil, award: String? = nil
   ) async throws -> Int {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/related")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/related")
     var body: [String: Any] = [
       "cat": cat.rawValue,
       "sid": sid,
@@ -102,7 +102,7 @@ enum IndexService {
   }
 
   static func patchIndexRelated(indexId: Int, id: Int, order: Int, comment: String) async throws {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/related/\(id)")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/related/\(id)")
     let body: [String: Any] = [
       "order": order,
       "comment": comment,
@@ -111,13 +111,13 @@ enum IndexService {
   }
 
   static func deleteIndexRelated(indexId: Int, id: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/related/\(id)")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/related/\(id)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body)
   }
 
   static func getIndexComments(_ indexId: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/comments")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/comments")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -126,7 +126,7 @@ enum IndexService {
   static func createIndexComment(indexId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/indexes/\(indexId)/comments")
+    let url = BangumiURL.next(path: "p1/indexes/\(indexId)/comments")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,

--- a/App/Client/PersonService.swift
+++ b/App/Client/PersonService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum PersonService {
   static func getPerson(_ personId: Int) async throws -> PersonDTO {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let person: PersonDTO = try await APIClient.shared.decodeResponse(data)
     return person
@@ -12,7 +12,7 @@ enum PersonService {
     _ personId: Int, position: Int? = nil, subjectType: SubjectType = .none,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<PersonWorkDTO> {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/works")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/works")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -33,7 +33,7 @@ enum PersonService {
     _ personId: Int, type: Int? = nil, subjectType: SubjectType? = nil,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<PersonCastDTO> {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/casts")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/casts")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -53,7 +53,7 @@ enum PersonService {
   static func getPersonRelations(_ personId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<PersonRelationDTO>
   {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/relations")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/relations")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -67,7 +67,7 @@ enum PersonService {
   static func getPersonCollects(_ personId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<PersonCollectDTO>
   {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/collects")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/collects")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -81,7 +81,7 @@ enum PersonService {
   static func getPersonIndexes(personId: Int, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<SlimIndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/indexes")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/indexes")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -93,7 +93,7 @@ enum PersonService {
   }
 
   static func getPersonComments(_ personId: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/comments")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/comments")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -102,7 +102,7 @@ enum PersonService {
   static func createPersonComment(personId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/persons/\(personId)/comments")
+    let url = BangumiURL.next(path: "p1/persons/\(personId)/comments")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,
@@ -114,13 +114,13 @@ enum PersonService {
   }
 
   static func collectPerson(_ personId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/persons/\(personId)")
+    let url = BangumiURL.next(path: "p1/collections/persons/\(personId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
 
   static func uncollectPerson(_ personId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/persons/\(personId)")
+    let url = BangumiURL.next(path: "p1/collections/persons/\(personId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }

--- a/App/Client/PrivacyService.swift
+++ b/App/Client/PrivacyService.swift
@@ -55,7 +55,7 @@ struct ProfilePrivacyDTO: Codable, Equatable, Sendable {
 
 enum PrivacyService {
   static func getProfilePrivacy() async throws -> ProfilePrivacyDTO {
-    let url = BangumiAPI.priv.build("p1/privacy")
+    let url = BangumiURL.next(path: "p1/privacy")
     let data = try await APIClient.shared.request(url: url, method: "GET", auth: .required)
     let resp: ProfilePrivacyDTO = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -65,7 +65,7 @@ enum PrivacyService {
     settings: ProfilePrivacySettingsDTO,
     showNsfwSubject: Bool?
   ) async throws -> ProfilePrivacyDTO {
-    let url = BangumiAPI.priv.build("p1/privacy")
+    let url = BangumiURL.next(path: "p1/privacy")
     var body: [String: Any] = [
       "settings": [
         "privateMessage": settings.privateMessage.rawValue,

--- a/App/Client/SearchService.swift
+++ b/App/Client/SearchService.swift
@@ -5,7 +5,7 @@ enum SearchService {
     keyword: String, type: SubjectType = .none, limit: Int = 10, offset: Int = 0
   ) async throws -> PagedDTO<SlimSubjectDTO> {
     let queries = paginationQueryItems(limit: limit, offset: offset)
-    let url = BangumiAPI.priv.build("p1/search/subjects").appending(queryItems: queries)
+    let url = BangumiURL.next(path: "p1/search/subjects").appending(queryItems: queries)
     var body: [String: Any] = [
       "keyword": keyword,
       "sort": "match",
@@ -23,7 +23,7 @@ enum SearchService {
   static func searchCharacters(keyword: String, limit: Int = 10, offset: Int = 0) async throws
     -> PagedDTO<SlimCharacterDTO>
   {
-    let url = BangumiAPI.priv.build("p1/search/characters").appending(
+    let url = BangumiURL.next(path: "p1/search/characters").appending(
       queryItems: paginationQueryItems(limit: limit, offset: offset))
     let body: [String: Any] = ["keyword": keyword]
     let data = try await APIClient.shared.request(url: url, method: "POST", body: body)
@@ -34,7 +34,7 @@ enum SearchService {
   static func searchPersons(keyword: String, limit: Int = 10, offset: Int = 0) async throws
     -> PagedDTO<SlimPersonDTO>
   {
-    let url = BangumiAPI.priv.build("p1/search/persons").appending(
+    let url = BangumiURL.next(path: "p1/search/persons").appending(
       queryItems: paginationQueryItems(limit: limit, offset: offset))
     let body: [String: Any] = ["keyword": keyword]
     let data = try await APIClient.shared.request(url: url, method: "POST", body: body)

--- a/App/Client/SubjectService.swift
+++ b/App/Client/SubjectService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum SubjectService {
   static func getSubject(_ subjectId: Int) async throws -> SubjectDTO {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let subject: SubjectDTO = try await APIClient.shared.decodeResponse(data)
     return subject
@@ -14,7 +14,7 @@ enum SubjectService {
     filter: SubjectsBrowseFilter,
     page: Int = 1
   ) async throws -> PagedDTO<SlimSubjectDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects")
+    let url = BangumiURL.next(path: "p1/subjects")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "type", value: String(type.rawValue)),
       URLQueryItem(name: "sort", value: sort.rawValue),
@@ -50,7 +50,7 @@ enum SubjectService {
     _ subjectId: Int, type: CastType = .none,
     limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<SubjectCharacterDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/characters")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/characters")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -67,7 +67,7 @@ enum SubjectService {
   static func getSubjectComments(_ subjectId: Int, limit: Int, offset: Int = 0) async throws
     -> PagedDTO<SubjectCommentDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/comments")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/comments")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -81,7 +81,7 @@ enum SubjectService {
   static func getSubjectEpisodes(
     _ subjectId: Int, type: EpisodeType? = nil, limit: Int = 100, offset: Int = 0
   ) async throws -> PagedDTO<EpisodeDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/episodes")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/episodes")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -98,7 +98,7 @@ enum SubjectService {
   static func getSubjectRecs(_ subjectId: Int, limit: Int = 10, offset: Int = 0) async throws
     -> PagedDTO<SubjectRecDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/recs")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/recs")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -113,7 +113,7 @@ enum SubjectService {
     _ subjectId: Int, type: SubjectType = .none, offprint: Bool? = nil, limit: Int = 20,
     offset: Int = 0
   ) async throws -> PagedDTO<SubjectRelationDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/relations")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/relations")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -133,7 +133,7 @@ enum SubjectService {
   static func getSubjectReviews(_ subjectId: Int, limit: Int = 5, offset: Int = 0) async throws
     -> PagedDTO<SubjectReviewDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/reviews")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/reviews")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -151,7 +151,7 @@ enum SubjectService {
     limit: Int = 20,
     offset: Int = 0
   ) async throws -> PagedDTO<SubjectCollectDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/collects")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/collects")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -171,7 +171,7 @@ enum SubjectService {
   static func getSubjectStaffPersons(
     _ subjectId: Int, position: Int? = nil, limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<SubjectStaffDTO> {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/staffs/persons")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/staffs/persons")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -188,7 +188,7 @@ enum SubjectService {
   static func getSubjectStaffPositions(_ subjectId: Int, limit: Int = 100, offset: Int = 0)
     async throws -> PagedDTO<SubjectPositionDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/staffs/positions")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/staffs/positions")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -202,7 +202,7 @@ enum SubjectService {
   static func getSubjectIndexes(subjectId: Int, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimIndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/indexes")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/indexes")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -216,7 +216,7 @@ enum SubjectService {
   static func getSubjectTopics(_ subjectId: Int, limit: Int, offset: Int = 0) async throws
     -> PagedDTO<TopicDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/topics")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/topics")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "offset", value: String(offset)),
@@ -228,7 +228,7 @@ enum SubjectService {
   }
 
   static func updateSubjectProgress(subjectId: Int, eps: Int?, vols: Int?) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/subjects/\(subjectId)")
+    let url = BangumiURL.next(path: "p1/collections/subjects/\(subjectId)")
     var body: [String: Any] = [:]
     if let eps {
       body["epStatus"] = eps
@@ -252,7 +252,7 @@ enum SubjectService {
     tags: [String]?,
     progress: Bool?
   ) async throws {
-    let url = BangumiAPI.priv.build("p1/collections/subjects/\(subjectId)")
+    let url = BangumiURL.next(path: "p1/collections/subjects/\(subjectId)")
     var body: [String: Any] = [:]
     if let type {
       body["type"] = type.rawValue

--- a/App/Client/TimelineService.swift
+++ b/App/Client/TimelineService.swift
@@ -4,7 +4,7 @@ enum TimelineService {
   static func getTimeline(mode: TimelineMode = .friends, limit: Int = 20, until: Int? = nil)
     async throws -> [TimelineDTO]
   {
-    let url = BangumiAPI.priv.build("p1/timeline")
+    let url = BangumiURL.next(path: "p1/timeline")
     var queryItems: [URLQueryItem] = [
       URLQueryItem(name: "mode", value: mode.rawValue),
       URLQueryItem(name: "limit", value: String(limit)),
@@ -19,14 +19,14 @@ enum TimelineService {
   }
 
   static func getTimelineReplies(_ id: Int) async throws -> [CommentDTO] {
-    let url = BangumiAPI.priv.build("p1/timeline/\(id)/replies")
+    let url = BangumiURL.next(path: "p1/timeline/\(id)/replies")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: [CommentDTO] = try await APIClient.shared.decodeResponse(data)
     return resp
   }
 
   static func postTimeline(content: String, token: String) async throws {
-    let url = BangumiAPI.priv.build("p1/timeline")
+    let url = BangumiURL.next(path: "p1/timeline")
     let body: [String: Any] = [
       "content": content,
       "turnstileToken": token,
@@ -38,7 +38,7 @@ enum TimelineService {
   static func postTimelineReply(timelineId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/timeline/\(timelineId)/replies")
+    let url = BangumiURL.next(path: "p1/timeline/\(timelineId)/replies")
     var body: [String: Any] = [
       "content": content,
       "turnstileToken": token,

--- a/App/Client/TopicService.swift
+++ b/App/Client/TopicService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum TopicService {
   static func getGroupTopic(_ topicId: Int) async throws -> GroupTopicDTO {
-    let url = BangumiAPI.priv.build("p1/groups/-/topics/\(topicId)")
+    let url = BangumiURL.next(path: "p1/groups/-/topics/\(topicId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: GroupTopicDTO = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -11,7 +11,7 @@ enum TopicService {
   static func createGroupTopic(groupName: String, title: String, content: String, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/groups/\(groupName)/topics")
+    let url = BangumiURL.next(path: "p1/groups/\(groupName)/topics")
     let body: [String: Any] = [
       "title": title,
       "content": content,
@@ -21,7 +21,7 @@ enum TopicService {
   }
 
   static func getSubjectTopic(_ topicId: Int) async throws -> SubjectTopicDTO {
-    let url = BangumiAPI.priv.build("p1/subjects/-/topics/\(topicId)")
+    let url = BangumiURL.next(path: "p1/subjects/-/topics/\(topicId)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let resp: SubjectTopicDTO = try await APIClient.shared.decodeResponse(data)
     return resp
@@ -30,7 +30,7 @@ enum TopicService {
   static func createSubjectTopic(subjectId: Int, title: String, content: String, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/subjects/\(subjectId)/topics")
+    let url = BangumiURL.next(path: "p1/subjects/\(subjectId)/topics")
     let body: [String: Any] = [
       "title": title,
       "content": content,
@@ -54,7 +54,7 @@ enum TopicService {
   static func getTrendingSubjectTopics(limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SubjectTopicDTO>
   {
-    let url = BangumiAPI.priv.build("p1/trending/subjects/topics")
+    let url = BangumiURL.next(path: "p1/trending/subjects/topics")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -65,7 +65,7 @@ enum TopicService {
   static func getRecentSubjectTopics(limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SubjectTopicDTO>
   {
-    let url = BangumiAPI.priv.build("p1/subjects/-/topics")
+    let url = BangumiURL.next(path: "p1/subjects/-/topics")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -76,7 +76,7 @@ enum TopicService {
   static func getRecentGroupTopics(
     mode: GroupTopicFilterMode = .joined, limit: Int = 20, offset: Int = 0
   ) async throws -> PagedDTO<GroupTopicDTO> {
-    let url = BangumiAPI.priv.build("p1/groups/-/topics")
+    let url = BangumiURL.next(path: "p1/groups/-/topics")
     let queryItems: [URLQueryItem] = [
       URLQueryItem(name: "mode", value: mode.rawValue),
       URLQueryItem(name: "limit", value: String(limit)),
@@ -89,13 +89,13 @@ enum TopicService {
   }
 
   static func deleteSubjectPost(postId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/subjects/-/posts/\(postId)")
+    let url = BangumiURL.next(path: "p1/subjects/-/posts/\(postId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }
 
   static func editSubjectPost(postId: Int, content: String) async throws {
-    let url = BangumiAPI.priv.build("p1/subjects/-/posts/\(postId)")
+    let url = BangumiURL.next(path: "p1/subjects/-/posts/\(postId)")
     let body: [String: Any] = ["content": content]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
@@ -103,13 +103,13 @@ enum TopicService {
   static func createSubjectReply(topicId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/subjects/-/topics/\(topicId)/replies")
+    let url = BangumiURL.next(path: "p1/subjects/-/topics/\(topicId)/replies")
     let body = replyBody(content: content, replyTo: replyTo, token: token)
     _ = try await APIClient.shared.request(url: url, method: "POST", body: body, auth: .required)
   }
 
   static func editSubjectTopic(topicId: Int, title: String, content: String) async throws {
-    let url = BangumiAPI.priv.build("p1/subjects/-/topics/\(topicId)")
+    let url = BangumiURL.next(path: "p1/subjects/-/topics/\(topicId)")
     let body: [String: Any] = [
       "title": title,
       "content": content,
@@ -118,13 +118,13 @@ enum TopicService {
   }
 
   static func deleteGroupPost(postId: Int) async throws {
-    let url = BangumiAPI.priv.build("p1/groups/-/posts/\(postId)")
+    let url = BangumiURL.next(path: "p1/groups/-/posts/\(postId)")
     let body: [String: Any] = [:]
     _ = try await APIClient.shared.request(url: url, method: "DELETE", body: body, auth: .required)
   }
 
   static func editGroupPost(postId: Int, content: String) async throws {
-    let url = BangumiAPI.priv.build("p1/groups/-/posts/\(postId)")
+    let url = BangumiURL.next(path: "p1/groups/-/posts/\(postId)")
     let body: [String: Any] = ["content": content]
     _ = try await APIClient.shared.request(url: url, method: "PUT", body: body, auth: .required)
   }
@@ -132,13 +132,13 @@ enum TopicService {
   static func createGroupReply(topicId: Int, content: String, replyTo: Int?, token: String)
     async throws
   {
-    let url = BangumiAPI.priv.build("p1/groups/-/topics/\(topicId)/replies")
+    let url = BangumiURL.next(path: "p1/groups/-/topics/\(topicId)/replies")
     let body = replyBody(content: content, replyTo: replyTo, token: token)
     _ = try await APIClient.shared.request(url: url, method: "POST", body: body, auth: .required)
   }
 
   static func editGroupTopic(topicId: Int, title: String, content: String) async throws {
-    let url = BangumiAPI.priv.build("p1/groups/-/topics/\(topicId)")
+    let url = BangumiURL.next(path: "p1/groups/-/topics/\(topicId)")
     let body: [String: Any] = [
       "title": title,
       "content": content,

--- a/App/Client/UserService.swift
+++ b/App/Client/UserService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum UserService {
   static func getUser(_ username: String) async throws -> UserDTO {
-    let url = BangumiAPI.priv.build("p1/users/\(username)")
+    let url = BangumiURL.next(path: "p1/users/\(username)")
     let data = try await APIClient.shared.request(url: url, method: "GET")
     let user: UserDTO = try await APIClient.shared.decodeResponse(data)
     return user
@@ -11,7 +11,7 @@ enum UserService {
   static func getUserBlogs(username: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimBlogEntryDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/blogs")
+    let url = BangumiURL.next(path: "p1/users/\(username)/blogs")
     let queryItems = paginationQueryItems(limit: limit, offset: offset)
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: queryItems), method: "GET")
@@ -22,7 +22,7 @@ enum UserService {
   static func getUserCharacterCollections(username: String, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<SlimCharacterDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/collections/characters")
+    let url = BangumiURL.next(path: "p1/users/\(username)/collections/characters")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -33,7 +33,7 @@ enum UserService {
   static func getUserIndexCollections(username: String, limit: Int = 20, offset: Int = 0)
     async throws -> PagedDTO<SlimIndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/collections/indexes")
+    let url = BangumiURL.next(path: "p1/users/\(username)/collections/indexes")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -47,7 +47,7 @@ enum UserService {
     if username.isEmpty {
       throw ChiiError.badRequest("username is empty")
     }
-    let url = BangumiAPI.priv.build("p1/users/\(username)/collections/persons")
+    let url = BangumiURL.next(path: "p1/users/\(username)/collections/persons")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -65,7 +65,7 @@ enum UserService {
     if username.isEmpty {
       throw ChiiError.badRequest("username is empty")
     }
-    let url = BangumiAPI.priv.build("p1/users/\(username)/collections/subjects")
+    let url = BangumiURL.next(path: "p1/users/\(username)/collections/subjects")
     var queryItems = paginationQueryItems(limit: limit, offset: offset)
     if type != .none {
       queryItems.append(URLQueryItem(name: "type", value: String(type.rawValue)))
@@ -82,7 +82,7 @@ enum UserService {
   static func getUserFollowers(username: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimUserDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/followers")
+    let url = BangumiURL.next(path: "p1/users/\(username)/followers")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -93,7 +93,7 @@ enum UserService {
   static func getUserFriends(username: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimUserDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/friends")
+    let url = BangumiURL.next(path: "p1/users/\(username)/friends")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -104,7 +104,7 @@ enum UserService {
   static func getUserGroups(username: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimGroupDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/groups")
+    let url = BangumiURL.next(path: "p1/users/\(username)/groups")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -115,7 +115,7 @@ enum UserService {
   static func getUserIndexes(username: String, limit: Int = 20, offset: Int = 0) async throws
     -> PagedDTO<SlimIndexDTO>
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/indexes")
+    let url = BangumiURL.next(path: "p1/users/\(username)/indexes")
     let data = try await APIClient.shared.request(
       url: url.appending(queryItems: paginationQueryItems(limit: limit, offset: offset)),
       method: "GET")
@@ -126,7 +126,7 @@ enum UserService {
   static func getUserTimeline(username: String, limit: Int = 20, until: Int? = nil) async throws
     -> [TimelineDTO]
   {
-    let url = BangumiAPI.priv.build("p1/users/\(username)/timeline")
+    let url = BangumiURL.next(path: "p1/users/\(username)/timeline")
     var queryItems = [URLQueryItem(name: "limit", value: String(limit))]
     if let until {
       queryItems.append(URLQueryItem(name: "until", value: String(until)))

--- a/App/Components/Image+View/ImageView.swift
+++ b/App/Components/Image+View/ImageView.swift
@@ -13,7 +13,7 @@ struct ImageView: View {
   init(img: String?) {
     if let img = img, !img.isEmpty {
       let urlString = img.replacing("http://", with: "https://")
-      self.imageURL = URL(string: urlString)
+      self.imageURL = URL(string: BangumiURL.imageURLString(from: urlString))
     } else {
       self.imageURL = nil
     }

--- a/App/Components/TurnstileView.swift
+++ b/App/Components/TurnstileView.swift
@@ -49,7 +49,10 @@ struct TrunstileView: UIViewRepresentable {
     config.userContentController = userController
     let webView = WKWebView(frame: .zero, configuration: config)
     webView.scrollView.isScrollEnabled = false
-    webView.loadHTMLString(turnstileHTML, baseURL: URL(string: "https://next.bgm.tv/turnstile")!)
+    webView.loadHTMLString(
+      turnstileHTML,
+      baseURL: BangumiURL.next(path: "/turnstile")
+    )
     return webView
   }
 

--- a/App/Helpers/Setting.swift
+++ b/App/Helpers/Setting.swift
@@ -91,6 +91,15 @@ enum AuthDomain: String, CaseIterable {
       self = .next
     }
   }
+
+  var title: String {
+    switch self {
+    case .origin:
+      "主站"
+    case .next:
+      "Next"
+    }
+  }
 }
 
 enum TimelineViewMode: String, CaseIterable {

--- a/App/Helpers/Setting.swift
+++ b/App/Helpers/Setting.swift
@@ -46,6 +46,7 @@ enum ShareDomain: String, CaseIterable {
   case chii = "chii.in"
   case bgm = "bgm.tv"
   case bangumi = "bangumi.tv"
+  case mirror = "mirror"
 
   init(_ label: String? = nil) {
     switch label {
@@ -55,13 +56,24 @@ enum ShareDomain: String, CaseIterable {
       self = .bgm
     case "bangumi.tv":
       self = .bangumi
+    case "mirror":
+      self = .mirror
     default:
       self = .chii
     }
   }
 
+  var title: String {
+    switch self {
+    case .mirror:
+      "镜像站"
+    default:
+      rawValue
+    }
+  }
+
   var url: String {
-    "https://\(self.rawValue)"
+    BangumiURL.shareRootURL(for: self).absoluteString
   }
 }
 

--- a/App/MainApp.swift
+++ b/App/MainApp.swift
@@ -7,6 +7,7 @@ struct MainApp: App {
   @State private var bootstrapState: BootstrapState = .migrating
 
   @AppStorage("appearance") var appearance: AppearanceType = .system
+  @AppStorage("mirrorRootDomain") var mirrorRootDomain: String = ""
 
   init() {
     AppMetadata.setup()
@@ -28,6 +29,7 @@ struct MainApp: App {
       .task {
         await bootstrap()
       }
+      .environment(\.bangumiDomains, BangumiDomains(mirrorRootDomain: mirrorRootDomain))
       .preferredColorScheme(appearance.colorScheme)
     }
   }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -48,12 +48,12 @@ struct SettingsView: View {
     }
   }
 
-  private func shareDomainTitle(for domain: ShareDomain) -> String {
-    domain.title
+  private var shareDomainDescription: String {
+    "当前：\(BangumiURL.shareHost(for: shareDomain))"
   }
 
-  private func authDomainTitle(for domain: AuthDomain) -> String {
-    domain.title
+  private var authDomainDescription: String {
+    "当前：\(BangumiURL.authHost(for: authDomain))"
   }
 
   func reindex() {
@@ -225,18 +225,18 @@ struct SettingsView: View {
       Section {
         Picker(selection: $shareDomain) {
           ForEach(ShareDomain.allCases, id: \.self) { domain in
-            Text(shareDomainTitle(for: domain)).tag(domain)
+            Text(domain.title).tag(domain)
           }
         } label: {
-          SettingLabel("分享域名", description: "分享链接时使用的域名")
+          SettingLabel("分享域名", description: "\(shareDomainDescription)")
         }
 
         Picker(selection: $authDomain) {
           ForEach(AuthDomain.allCases, id: \.self) { domain in
-            Text(authDomainTitle(for: domain)).tag(domain)
+            Text(domain.title).tag(domain)
           }
         } label: {
-          SettingLabel("认证域名", description: "OAuth 认证服务器")
+          SettingLabel("认证域名", description: "\(authDomainDescription)")
         }
 
         Button {
@@ -254,12 +254,6 @@ struct SettingsView: View {
         .buttonStyle(.plain)
       } header: {
         Text("网络")
-      } footer: {
-        if hasMirrorRootDomain {
-          Text(
-            "当前认证：\(BangumiURL.authHost(for: authDomain))\n当前分享：\(BangumiURL.shareHost(for: shareDomain))"
-          )
-        }
       }
 
       // MARK: - 关于

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
   @AppStorage("appearance") var appearance: AppearanceType = .system
   @AppStorage("shareDomain") var shareDomain: ShareDomain = .chii
   @AppStorage("authDomain") var authDomain: AuthDomain = .next
+  @AppStorage("mirrorRootDomain") var mirrorRootDomain: String = ""
   @AppStorage("subjectImageQuality") var subjectImageQuality: ImageQuality = .high
   @AppStorage("isolationMode") var isolationMode: Bool = false
   @AppStorage("showNSFWBadge") var showNSFWBadge: Bool = true
@@ -216,8 +217,31 @@ struct SettingsView: View {
         } label: {
           SettingLabel("认证域名", description: "OAuth 认证服务器域名")
         }
+
+        VStack(alignment: .leading, spacing: 8) {
+          SettingLabel("镜像站", description: "留空时使用官方域名")
+          HStack {
+            TextField("根域名", text: $mirrorRootDomain, prompt: Text("example.com"))
+              .keyboardType(.URL)
+              .textInputAutocapitalization(.never)
+              .autocorrectionDisabled()
+
+            if !mirrorRootDomain.isEmpty {
+              Button {
+                mirrorRootDomain = ""
+              } label: {
+                Image(systemName: "xmark.circle.fill")
+                  .foregroundStyle(.secondary)
+              }
+              .buttonStyle(.plain)
+              .accessibilityLabel("清空镜像站")
+            }
+          }
+        }
       } header: {
         Text("网络")
+      } footer: {
+        Text("仅在你信任该镜像站时填写。登录、请求和图片会发送到该站点；使用风险自负。")
       }
 
       // MARK: - 关于

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -27,12 +27,58 @@ struct SettingsView: View {
   @State private var logoutConfirm: Bool = false
   @State private var clearDraftsConfirm: Bool = false
   @State private var showEULA: Bool = false
+  @State private var showMirrorDomainSettings: Bool = false
   @State private var appIconController = AppIconController()
 
   private var privacyPolicyURL: String {
     let langCode = Locale.current.language.languageCode?.identifier ?? "zh"
     let lang = langCode.hasPrefix("zh") ? "zh" : "en"
     return "https://bangumi.github.io/Bangumi-iOS/privacy/\(lang)/"
+  }
+
+  private var hasMirrorRootDomain: Bool {
+    BangumiURL.normalizedMirrorRootDomain(mirrorRootDomain) != nil
+  }
+
+  private var mirrorStatusDescription: String {
+    if hasMirrorRootDomain {
+      "当前主站：\(BangumiURL.domains.main)"
+    } else {
+      "留空时使用官方域名"
+    }
+  }
+
+  private var shareDomainDescription: String {
+    "分享链接时使用：\(BangumiURL.shareHost(for: shareDomain))"
+  }
+
+  private var authDomainDescription: String {
+    "OAuth 认证服务器：\(BangumiURL.authHost(for: authDomain))"
+  }
+
+  private func shareDomainTitle(for domain: ShareDomain) -> String {
+    guard domain == .mirror else {
+      return domain.title
+    }
+
+    if hasMirrorRootDomain {
+      return "镜像站（\(BangumiURL.shareHost(for: domain))）"
+    }
+    return "镜像站（未启用）"
+  }
+
+  private func authDomainTitle(for domain: AuthDomain) -> String {
+    let host = BangumiURL.authHost(for: domain)
+    guard hasMirrorRootDomain else {
+      return host
+    }
+
+    switch domain {
+    case .origin:
+      return "镜像主站（\(host)）"
+    case .next:
+      return "镜像 Next（\(host)）"
+    }
   }
 
   func reindex() {
@@ -204,44 +250,35 @@ struct SettingsView: View {
       Section {
         Picker(selection: $shareDomain) {
           ForEach(ShareDomain.allCases, id: \.self) { domain in
-            Text(domain.rawValue).tag(domain)
+            Text(shareDomainTitle(for: domain)).tag(domain)
           }
         } label: {
-          SettingLabel("分享域名", description: "分享链接时使用的域名")
+          SettingLabel("分享域名", description: "\(shareDomainDescription)")
         }
 
         Picker(selection: $authDomain) {
           ForEach(AuthDomain.allCases, id: \.self) { domain in
-            Text(domain.rawValue).tag(domain)
+            Text(authDomainTitle(for: domain)).tag(domain)
           }
         } label: {
-          SettingLabel("认证域名", description: "OAuth 认证服务器域名")
+          SettingLabel("认证域名", description: "\(authDomainDescription)")
         }
 
-        VStack(alignment: .leading, spacing: 8) {
-          SettingLabel("镜像站", description: "留空时使用官方域名")
+        Button {
+          showMirrorDomainSettings = true
+        } label: {
           HStack {
-            TextField("根域名", text: $mirrorRootDomain, prompt: Text("example.com"))
-              .keyboardType(.URL)
-              .textInputAutocapitalization(.never)
-              .autocorrectionDisabled()
-
-            if !mirrorRootDomain.isEmpty {
-              Button {
-                mirrorRootDomain = ""
-              } label: {
-                Image(systemName: "xmark.circle.fill")
-                  .foregroundStyle(.secondary)
-              }
-              .buttonStyle(.plain)
-              .accessibilityLabel("清空镜像站")
-            }
+            SettingLabel("镜像站", description: "\(mirrorStatusDescription)")
+            Spacer()
+            Image(systemName: "chevron.right")
+              .font(.caption)
+              .foregroundStyle(.tertiary)
           }
+          .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
       } header: {
         Text("网络")
-      } footer: {
-        Text("仅在你信任该镜像站时填写。登录、请求和图片会发送到该站点；使用风险自负。")
       }
 
       // MARK: - 关于
@@ -348,6 +385,9 @@ struct SettingsView: View {
     .sheet(isPresented: $showEULA) {
       EULAView(isPresented: $showEULA, showLoginButton: false)
     }
+    .sheet(isPresented: $showMirrorDomainSettings) {
+      MirrorDomainSettingsView(mirrorRootDomain: $mirrorRootDomain)
+    }
     .alert("清空草稿箱", isPresented: $clearDraftsConfirm) {
       Button("确定", role: .destructive) {
         clearDrafts()
@@ -363,6 +403,135 @@ struct SettingsView: View {
       }
     } message: {
       Text("确定要退出登录吗？")
+    }
+  }
+}
+
+private struct MirrorDomainSettingsView: View {
+  @Environment(\.dismiss) private var dismiss
+
+  @Binding private var mirrorRootDomain: String
+  @State private var draftRootDomain: String
+  @FocusState private var isDomainFieldFocused: Bool
+
+  init(mirrorRootDomain: Binding<String>) {
+    self._mirrorRootDomain = mirrorRootDomain
+    self._draftRootDomain = State(initialValue: mirrorRootDomain.wrappedValue)
+  }
+
+  private var trimmedDraftRootDomain: String {
+    draftRootDomain.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var normalizedDraftRootDomain: String? {
+    BangumiURL.normalizedMirrorRootDomain(trimmedDraftRootDomain)
+  }
+
+  private var savedMirrorRootDomain: String? {
+    BangumiURL.normalizedMirrorRootDomain(mirrorRootDomain)
+  }
+
+  private var isDraftEmpty: Bool {
+    trimmedDraftRootDomain.isEmpty
+  }
+
+  private var isDraftValid: Bool {
+    isDraftEmpty || normalizedDraftRootDomain != nil
+  }
+
+  private var previewMainHost: String {
+    BangumiURL.domains(mirrorRootDomain: normalizedDraftRootDomain).main
+  }
+
+  private var previewImageHost: String {
+    BangumiURL.domains(mirrorRootDomain: normalizedDraftRootDomain).image
+  }
+
+  private var previewNextHost: String {
+    BangumiURL.domains(mirrorRootDomain: normalizedDraftRootDomain).next
+  }
+
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section {
+          TextField("根域名", text: $draftRootDomain, prompt: Text("example.com"))
+            .keyboardType(.URL)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
+            .focused($isDomainFieldFocused)
+
+          if !isDraftValid {
+            Text("请输入有效域名，例如 example.com。")
+              .font(.caption)
+              .foregroundStyle(.red)
+          }
+        } footer: {
+          Text("仅在你信任该镜像站时填写。登录、请求、图片、BBCode 生成链接和镜像分享链接会发送到该站点；使用风险自负。")
+        }
+
+        if isDraftValid {
+          Section {
+            MirrorDomainPreviewRow(title: "主站", host: previewMainHost)
+            MirrorDomainPreviewRow(title: "Next/API", host: previewNextHost)
+            MirrorDomainPreviewRow(title: "图片", host: previewImageHost)
+            MirrorDomainPreviewRow(title: "分享镜像", host: previewMainHost)
+          } header: {
+            Text("生效域名")
+          } footer: {
+            Text("分享链接仅在分享域名选择「镜像站」时使用该域名。")
+          }
+        }
+
+        if savedMirrorRootDomain != nil {
+          Section {
+            Button("停用镜像站", role: .destructive) {
+              mirrorRootDomain = ""
+              dismiss()
+            }
+          }
+        }
+      }
+      .navigationTitle("镜像站")
+      .navigationBarTitleDisplayMode(.inline)
+      .scrollDismissesKeyboard(.interactively)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("取消") {
+            dismiss()
+          }
+        }
+
+        ToolbarItem(placement: .confirmationAction) {
+          Button("保存") {
+            save()
+          }
+          .disabled(!isDraftValid)
+        }
+      }
+      .onAppear {
+        isDomainFieldFocused = true
+      }
+    }
+  }
+
+  private func save() {
+    mirrorRootDomain = normalizedDraftRootDomain ?? ""
+    dismiss()
+  }
+}
+
+private struct MirrorDomainPreviewRow: View {
+  let title: String
+  let host: String
+
+  var body: some View {
+    HStack {
+      Text(title)
+      Spacer()
+      Text(host)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.trailing)
     }
   }
 }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -48,37 +48,12 @@ struct SettingsView: View {
     }
   }
 
-  private var shareDomainDescription: String {
-    "分享链接时使用：\(BangumiURL.shareHost(for: shareDomain))"
-  }
-
-  private var authDomainDescription: String {
-    "OAuth 认证服务器：\(BangumiURL.authHost(for: authDomain))"
-  }
-
   private func shareDomainTitle(for domain: ShareDomain) -> String {
-    guard domain == .mirror else {
-      return domain.title
-    }
-
-    if hasMirrorRootDomain {
-      return "镜像站（\(BangumiURL.shareHost(for: domain))）"
-    }
-    return "镜像站（未启用）"
+    domain.title
   }
 
   private func authDomainTitle(for domain: AuthDomain) -> String {
-    let host = BangumiURL.authHost(for: domain)
-    guard hasMirrorRootDomain else {
-      return host
-    }
-
-    switch domain {
-    case .origin:
-      return "镜像主站（\(host)）"
-    case .next:
-      return "镜像 Next（\(host)）"
-    }
+    domain.title
   }
 
   func reindex() {
@@ -253,7 +228,7 @@ struct SettingsView: View {
             Text(shareDomainTitle(for: domain)).tag(domain)
           }
         } label: {
-          SettingLabel("分享域名", description: "\(shareDomainDescription)")
+          SettingLabel("分享域名", description: "分享链接时使用的域名")
         }
 
         Picker(selection: $authDomain) {
@@ -261,7 +236,7 @@ struct SettingsView: View {
             Text(authDomainTitle(for: domain)).tag(domain)
           }
         } label: {
-          SettingLabel("认证域名", description: "\(authDomainDescription)")
+          SettingLabel("认证域名", description: "OAuth 认证服务器")
         }
 
         Button {
@@ -279,6 +254,12 @@ struct SettingsView: View {
         .buttonStyle(.plain)
       } header: {
         Text("网络")
+      } footer: {
+        if hasMirrorRootDomain {
+          Text(
+            "当前认证：\(BangumiURL.authHost(for: authDomain))\n当前分享：\(BangumiURL.shareHost(for: shareDomain))"
+          )
+        }
       }
 
       // MARK: - 关于

--- a/BBCode/Sources/BBCode/BangumiDomains.swift
+++ b/BBCode/Sources/BBCode/BangumiDomains.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftUI
+
+public struct BangumiDomains: Hashable, Sendable {
+  public static let official = BangumiDomains()
+
+  public let main: String
+  public let image: String
+  public let next: String
+
+  public init(
+    main: String = "bgm.tv",
+    image: String = "lain.bgm.tv",
+    next: String = "next.bgm.tv"
+  ) {
+    self.main = Self.normalizedDomain(main) ?? "bgm.tv"
+    self.image = Self.normalizedDomain(image) ?? "lain.bgm.tv"
+    self.next = Self.normalizedDomain(next) ?? "next.bgm.tv"
+  }
+
+  public init(mirrorRootDomain: String?) {
+    guard let root = Self.normalizedDomain(mirrorRootDomain) else {
+      self = .official
+      return
+    }
+
+    self.main = root
+    self.image = "lain.\(root)"
+    self.next = "next.\(root)"
+  }
+
+  public var cacheKey: String {
+    "\(main)|\(image)|\(next)"
+  }
+
+  public func mainURL(path: String = "") -> URL {
+    url(domain: main, path: path)
+  }
+
+  public func mainURLString(path: String = "") -> String {
+    urlString(domain: main, path: path)
+  }
+
+  public func imageURL(path: String = "") -> URL {
+    url(domain: image, path: path)
+  }
+
+  public func imageURLString(path: String = "") -> String {
+    urlString(domain: image, path: path)
+  }
+
+  public func nextURL(path: String = "") -> URL {
+    url(domain: next, path: path)
+  }
+
+  public func nextURLString(path: String = "") -> String {
+    urlString(domain: next, path: path)
+  }
+
+  private func url(domain: String, path: String) -> URL {
+    URL(string: urlString(domain: domain, path: path))!
+  }
+
+  private func urlString(domain: String, path: String) -> String {
+    let normalizedPath = path.isEmpty || path.hasPrefix("/") ? path : "/\(path)"
+    return "https://\(domain)\(normalizedPath)"
+  }
+
+  private static func normalizedDomain(_ rawValue: String?) -> String? {
+    guard let rawValue else {
+      return nil
+    }
+
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+
+    let candidate = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+    guard let components = URLComponents(string: candidate),
+      let host = components.host?.lowercased(),
+      !host.isEmpty
+    else {
+      return nil
+    }
+
+    if let port = components.port {
+      return "\(host):\(port)"
+    }
+    return host
+  }
+}
+
+private struct BangumiDomainsKey: EnvironmentKey {
+  static let defaultValue = BangumiDomains.official
+}
+
+extension EnvironmentValues {
+  public var bangumiDomains: BangumiDomains {
+    get { self[BangumiDomainsKey.self] }
+    set { self[BangumiDomainsKey.self] = newValue }
+  }
+}

--- a/BBCode/Sources/BBCode/BangumiDomains.swift
+++ b/BBCode/Sources/BBCode/BangumiDomains.swift
@@ -19,7 +19,7 @@ public struct BangumiDomains: Hashable, Sendable {
   }
 
   public init(mirrorRootDomain: String?) {
-    guard let root = Self.normalizedDomain(mirrorRootDomain) else {
+    guard let root = Self.normalizedRootDomain(mirrorRootDomain) else {
       self = .official
       return
     }
@@ -31,6 +31,10 @@ public struct BangumiDomains: Hashable, Sendable {
 
   public var cacheKey: String {
     "\(main)|\(image)|\(next)"
+  }
+
+  public static func normalizedRootDomain(_ rawValue: String?) -> String? {
+    normalizedDomain(rawValue)
   }
 
   public func mainURL(path: String = "") -> URL {

--- a/BBCode/Sources/BBCode/Renders/HTML.swift
+++ b/BBCode/Sources/BBCode/Renders/HTML.swift
@@ -35,6 +35,10 @@ extension Node {
   }
 }
 
+private func bangumiDomains(from args: [String: Any]?) -> BangumiDomains {
+  args?["domains"] as? BangumiDomains ?? .official
+}
+
 var htmlRenders: [BBType: HTMLRender] {
   return [
     .plain: { (n: Node, args: [String: Any]?) in
@@ -135,13 +139,14 @@ var htmlRenders: [BBType: HTMLRender] {
       return html
     },
     .subject: { (n: Node, args: [String: Any]?) in
+      let domains = bangumiDomains(from: args)
       let host = args?["host"] as? String
       var html: String
       var link: String
       if n.attr.isEmpty {
         html = n.renderInnerHTML(args)
       } else {
-        link = "https://bgm.tv/subject/\(n.escapedAttr)"
+        link = domains.mainURLString(path: "/subject/\(n.escapedAttr)")
         if let safeLink = safeUrl(url: link, defaultScheme: "https", defaultHost: host) {
           html =
             "<a href=\"\(safeLink)\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">\(n.renderInnerHTML(args))</a>"
@@ -152,13 +157,14 @@ var htmlRenders: [BBType: HTMLRender] {
       return html
     },
     .user: { (n: Node, args: [String: Any]?) in
+      let domains = bangumiDomains(from: args)
       let host = args?["host"] as? String
       var html: String
       var link: String
       if n.attr.isEmpty {
         html = n.renderInnerHTML(args)
       } else {
-        link = "https://bgm.tv/user/\(n.escapedAttr)"
+        link = domains.mainURLString(path: "/user/\(n.escapedAttr)")
         if let safeLink = safeUrl(url: link, defaultScheme: "https", defaultHost: host) {
           html =
             "<a href=\"\(safeLink)\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">@\(n.renderInnerHTML(args))</a>"
@@ -227,9 +233,10 @@ var htmlRenders: [BBType: HTMLRender] {
       }
     },
     .photo: { (n: Node, args: [String: Any]?) in
+      let domains = bangumiDomains(from: args)
       let host = args?["host"] as? String
       var html: String
-      let link: String = "https://lain.bgm.tv/pic/photo/l/\(n.renderInnerHTML(args))"
+      let link: String = domains.imageURLString(path: "/pic/photo/l/\(n.renderInnerHTML(args))")
       if let safeLink = safeUrl(url: link, defaultScheme: "https", defaultHost: host) {
         if n.attr.isEmpty {
           html =
@@ -353,8 +360,9 @@ var htmlRenders: [BBType: HTMLRender] {
       }
 
       let widthAttribute = smiley.preferredDisplayWidth.map { " width=\"\($0)\"" } ?? ""
+      let src = smiley.remoteURLString(domains: bangumiDomains(from: args))
       return
-        "<img src=\"\(smiley.remoteURLString)\" class=\"\(smiley.htmlClassString)\" alt=\"\(smiley.token)\"\(widthAttribute) />"
+        "<img src=\"\(src)\" class=\"\(smiley.htmlClassString)\" alt=\"\(smiley.token)\"\(widthAttribute) />"
     },
     .bmo: { (n: Node, args: [String: Any]?) in
       let bmoCode = n.attr
@@ -382,8 +390,17 @@ var htmlRenders: [BBType: HTMLRender] {
   ]
 }
 
-func BBCodeToHTML(code: String, textSize: Int) -> String {
-  guard let body = try? BBCode().html(code, args: ["textSize": textSize]) else {
+func BBCodeToHTML(
+  code: String,
+  textSize: Int,
+  domains: BangumiDomains = .official
+) -> String {
+  guard
+    let body = try? BBCode().html(
+      code,
+      args: ["textSize": textSize, "domains": domains]
+    )
+  else {
     return code
   }
   let html = """

--- a/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
+++ b/BBCode/Sources/BBCode/Renders/PreparedDocument.swift
@@ -12,14 +12,23 @@ private final class BBCodePreparedDocumentCache {
   private struct Key: Hashable {
     let bbcode: String
     let textSize: Int
+    let domainsCacheKey: String
   }
 
   private let limit = 256
   private var documents: [Key: BBCodePreparedDocument] = [:]
   private var accessOrder: [Key] = []
 
-  func document(for bbcode: String, textSize: Int) -> BBCodePreparedDocument? {
-    let key = Key(bbcode: bbcode, textSize: textSize)
+  func document(
+    for bbcode: String,
+    textSize: Int,
+    domains: BangumiDomains
+  ) -> BBCodePreparedDocument? {
+    let key = Key(
+      bbcode: bbcode,
+      textSize: textSize,
+      domainsCacheKey: domains.cacheKey
+    )
     guard let document = documents[key] else {
       return nil
     }
@@ -28,8 +37,17 @@ private final class BBCodePreparedDocumentCache {
     return document
   }
 
-  func store(_ document: BBCodePreparedDocument, for bbcode: String, textSize: Int) {
-    let key = Key(bbcode: bbcode, textSize: textSize)
+  func store(
+    _ document: BBCodePreparedDocument,
+    for bbcode: String,
+    textSize: Int,
+    domains: BangumiDomains
+  ) {
+    let key = Key(
+      bbcode: bbcode,
+      textSize: textSize,
+      domainsCacheKey: domains.cacheKey
+    )
     documents[key] = document
     markRecentlyUsed(key)
     trimIfNeeded()
@@ -87,10 +105,15 @@ enum BBCodeLayoutMetrics {
 
 extension BBCode {
   @MainActor
-  func preparedDocument(_ bbcode: String, textSize: Int) async -> BBCodePreparedDocument {
+  func preparedDocument(
+    _ bbcode: String,
+    textSize: Int,
+    domains: BangumiDomains = .official
+  ) async -> BBCodePreparedDocument {
     if let cachedDocument = BBCodePreparedDocumentCache.shared.document(
       for: bbcode,
-      textSize: textSize
+      textSize: textSize,
+      domains: domains
     ) {
       return cachedDocument
     }
@@ -104,14 +127,24 @@ extension BBCode {
           BBCodePreparedBlock(id: 0, payload: .text(renderer.makePlainText(bbcode)))
         ]
       )
-      BBCodePreparedDocumentCache.shared.store(document, for: bbcode, textSize: textSize)
+      BBCodePreparedDocumentCache.shared.store(
+        document,
+        for: bbcode,
+        textSize: textSize,
+        domains: domains
+      )
       return document
     }
 
     handleNewlineAndParagraph(node: tree, tagManager: tagManager)
-    let renderer = BBCodeTextKitRenderer(textSize: textSize)
+    let renderer = BBCodeTextKitRenderer(textSize: textSize, domains: domains)
     let document = BBCodePreparedDocument(blocks: renderer.renderBlocks(root: tree))
-    BBCodePreparedDocumentCache.shared.store(document, for: bbcode, textSize: textSize)
+    BBCodePreparedDocumentCache.shared.store(
+      document,
+      for: bbcode,
+      textSize: textSize,
+      domains: domains
+    )
     return document
   }
 }
@@ -140,9 +173,11 @@ private struct BBCodeTextKitRenderer {
   let linkColor: UIColor
   let secondaryColor: UIColor
   let baseParagraphStyle: NSParagraphStyle
+  let domains: BangumiDomains
 
-  init(textSize: Int) {
+  init(textSize: Int, domains: BangumiDomains = .official) {
     self.textSize = CGFloat(textSize)
+    self.domains = domains
     self.baseFont = .systemFont(ofSize: CGFloat(textSize))
     self.linkColor = UIColor(named: "LinkTextColor") ?? .systemBlue
     self.secondaryColor = .secondaryLabel
@@ -282,9 +317,10 @@ private struct BBCodeTextKitRenderer {
         node.attr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         ? subjectText
         : node.attr.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !subjectID.isEmpty, let url = URL(string: "https://bgm.tv/subject/\(subjectID)") else {
+      guard !subjectID.isEmpty else {
         return segments
       }
+      let url = domains.mainURL(path: "/subject/\(subjectID)")
 
       return mapTextSegments(segments) { attributed in
         applyLinkAttributes(to: attributed, url: url)
@@ -295,9 +331,10 @@ private struct BBCodeTextKitRenderer {
         node.attr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         ? usernameText
         : node.attr.trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !username.isEmpty, let url = URL(string: "https://bgm.tv/user/\(username)") else {
+      guard !username.isEmpty else {
         return segments
       }
+      let url = domains.mainURL(path: "/user/\(username)")
 
       let prefixedSegments = prefixFirstTextSegment(with: "@", in: segments)
       return mapTextSegments(prefixedSegments) { attributed in
@@ -608,11 +645,10 @@ private struct BBCodeTextKitRenderer {
       )
     case .photo:
       let path = node.renderInnerHTML(nil).trimmingCharacters(in: .whitespacesAndNewlines)
-      guard !path.isEmpty,
-        let url = URL(string: "https://lain.bgm.tv/pic/photo/l/\(path)")
-      else {
+      guard !path.isEmpty else {
         return nil
       }
+      let url = domains.imageURL(path: "/pic/photo/l/\(path)")
       return .image(
         BBCodePreparedMedia(
           url: url,
@@ -745,9 +781,10 @@ private struct BBCodeTextKitRenderer {
       node.attr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       ? inner.string.trimmingCharacters(in: .whitespacesAndNewlines)
       : node.attr.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !subjectID.isEmpty, let url = URL(string: "https://bgm.tv/subject/\(subjectID)") else {
+    guard !subjectID.isEmpty else {
       return inner
     }
+    let url = domains.mainURL(path: "/subject/\(subjectID)")
 
     applyLinkAttributes(to: inner, url: url)
     return inner
@@ -762,9 +799,10 @@ private struct BBCodeTextKitRenderer {
       node.attr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
       ? inner.string.trimmingCharacters(in: .whitespacesAndNewlines)
       : node.attr.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !username.isEmpty, let url = URL(string: "https://bgm.tv/user/\(username)") else {
+    guard !username.isEmpty else {
       return inner
     }
+    let url = domains.mainURL(path: "/user/\(username)")
 
     let result = NSMutableAttributedString(string: "")
     result.append(makeText("@"))

--- a/BBCode/Sources/BBCode/Smilies/SmileyCatalog.swift
+++ b/BBCode/Sources/BBCode/Smilies/SmileyCatalog.swift
@@ -10,6 +10,9 @@ public struct SmileyItem: Identifiable, Hashable, Sendable {
   public var id: String { code }
   public var token: String { "(\(code))" }
   public var remoteURLString: String { "https://lain.bgm.tv\(remotePath)" }
+  public func remoteURLString(domains: BangumiDomains) -> String {
+    domains.imageURLString(path: remotePath)
+  }
   public var isDynamic: Bool { code.hasPrefix("musume_") || code.hasPrefix("blake_") }
   public var preferredDisplayWidth: Int? {
     switch code {

--- a/BBCode/Sources/BBCode/Views/BBCodeView.swift
+++ b/BBCode/Sources/BBCode/Views/BBCodeView.swift
@@ -4,6 +4,7 @@ public struct BBCodeView: View {
   let code: String
   let textSize: Int
 
+  @Environment(\.bangumiDomains) private var domains
   @Environment(\.openURL) private var openURL
   @State private var document: BBCodePreparedDocument?
 
@@ -17,7 +18,7 @@ public struct BBCodeView: View {
       if let document {
         BBCodeDocumentView(
           document: document,
-          renderID: "\(textSize)|\(code)",
+          renderID: "\(domains.cacheKey)|\(textSize)|\(code)",
           openURLHandler: { url in
             openURL(url)
           }
@@ -27,8 +28,12 @@ public struct BBCodeView: View {
           .font(.system(size: CGFloat(textSize)))
       }
     }
-    .task(id: "\(textSize)|\(code)") {
-      document = await BBCode().preparedDocument(code, textSize: textSize)
+    .task(id: "\(domains.cacheKey)|\(textSize)|\(code)") {
+      document = await BBCode().preparedDocument(
+        code,
+        textSize: textSize,
+        domains: domains
+      )
     }
   }
 }

--- a/BBCode/Sources/BBCode/Views/WebView.swift
+++ b/BBCode/Sources/BBCode/Views/WebView.swift
@@ -4,12 +4,14 @@ import WebKit
 public struct BBCodeWebView: UIViewRepresentable {
   let code: String?
   let textSize: Int?
-  let htmlString: String
+  let htmlString: String?
+
+  @Environment(\.bangumiDomains) private var domains
 
   public init(_ code: String, textSize: Int = 16) {
     self.code = code
     self.textSize = textSize
-    self.htmlString = BBCodeToHTML(code: code, textSize: textSize)
+    self.htmlString = nil
   }
 
   init(htmlString: String) {
@@ -23,7 +25,19 @@ public struct BBCodeWebView: UIViewRepresentable {
   }
 
   public func updateUIView(_ uiView: WKWebView, context: Context) {
-    uiView.loadHTMLString(htmlString, baseURL: nil)
+    uiView.loadHTMLString(renderedHTML, baseURL: nil)
     uiView.invalidateIntrinsicContentSize()
+  }
+
+  private var renderedHTML: String {
+    if let htmlString {
+      return htmlString
+    }
+
+    return BBCodeToHTML(
+      code: code ?? "",
+      textSize: textSize ?? 16,
+      domains: domains
+    )
   }
 }

--- a/BBCode/Tests/BBCodeTests/HTMLTests.swift
+++ b/BBCode/Tests/BBCodeTests/HTMLTests.swift
@@ -3,6 +3,21 @@ import XCTest
 @testable import BBCode
 
 class HTMLTests: XCTestCase {
+  func testBangumiDomainsDefaultToOfficialDomains() {
+    let domains = BangumiDomains()
+
+    XCTAssertEqual(domains.main, "bgm.tv")
+    XCTAssertEqual(domains.image, "lain.bgm.tv")
+    XCTAssertEqual(domains.next, "next.bgm.tv")
+  }
+
+  func testBangumiDomainsUseMirrorRootForUsedDomains() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+
+    XCTAssertEqual(domains.main, "mirror.example")
+    XCTAssertEqual(domains.image, "lain.mirror.example")
+    XCTAssertEqual(domains.next, "next.mirror.example")
+  }
 
   func testBold() {
     XCTAssertEqual(try BBCode().html("我是[b]粗体字[/b]"), "我是<strong>粗体字</strong>")
@@ -90,10 +105,32 @@ class HTMLTests: XCTestCase {
     )
   }
 
+  func testSubjectUsesConfiguredMainDomain() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+    XCTAssertEqual(
+      try BBCode().html(
+        "条目链接：[subject=12]ちょびっツ[/subject]",
+        args: ["domains": domains]
+      ),
+      "条目链接：<a href=\"https://mirror.example/subject/12\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">&#12385;&#12423;&#12403;&#12387;&#12484;</a>"
+    )
+  }
+
   func testUser() {
     XCTAssertEqual(
       try BBCode().html("用户链接：[user=873244]五月雨[/user]"),
       "用户链接：<a href=\"https://bgm.tv/user/873244\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">@五月雨</a>"
+    )
+  }
+
+  func testUserUsesConfiguredMainDomain() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+    XCTAssertEqual(
+      try BBCode().html(
+        "用户链接：[user=873244]五月雨[/user]",
+        args: ["domains": domains]
+      ),
+      "用户链接：<a href=\"https://mirror.example/user/873244\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">@五月雨</a>"
     )
   }
 
@@ -104,10 +141,32 @@ class HTMLTests: XCTestCase {
     )
   }
 
+  func testURLAndImageKeepUserProvidedDomains() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+    XCTAssertEqual(
+      try BBCode().html(
+        "[url]https://bgm.tv/subject/12[/url][img]https://lain.bgm.tv/pic/photo/l/a.jpg[/img]",
+        args: ["domains": domains]
+      ),
+      "<a href=\"https://bgm.tv/subject/12\" target=\"_blank\" rel=\"nofollow external noopener noreferrer\">https://bgm.tv/subject/12</a><img src=\"https://lain.bgm.tv/pic/photo/l/a.jpg\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" alt=\"\" />"
+    )
+  }
+
   func testPhoto() {
     XCTAssertEqual(
       try BBCode().html("日志里的图片：[photo=104569]4b/d1/873244_3p4I7.jpg[/photo]"),
       "日志里的图片：<img src=\"https://lain.bgm.tv/pic/photo/l/4b/d1/873244_3p4I7.jpg\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" alt=\"104569\" />"
+    )
+  }
+
+  func testPhotoUsesConfiguredImageDomain() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+    XCTAssertEqual(
+      try BBCode().html(
+        "日志里的图片：[photo=104569]4b/d1/873244_3p4I7.jpg[/photo]",
+        args: ["domains": domains]
+      ),
+      "日志里的图片：<img src=\"https://lain.mirror.example/pic/photo/l/4b/d1/873244_3p4I7.jpg\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" alt=\"104569\" />"
     )
   }
 
@@ -129,6 +188,17 @@ class HTMLTests: XCTestCase {
     XCTAssertEqual(
       try BBCode().html("表情符号：(bgm38)"),
       "表情符号：<img src=\"https://lain.bgm.tv/img/smiles/tv/15.gif\" class=\"smile\" alt=\"(bgm38)\" />"
+    )
+  }
+
+  func testSmiliesUseConfiguredImageDomain() {
+    let domains = BangumiDomains(mirrorRootDomain: "mirror.example")
+    XCTAssertEqual(
+      try BBCode().html(
+        "表情符号：(bgm38)",
+        args: ["domains": domains]
+      ),
+      "表情符号：<img src=\"https://lain.mirror.example/img/smiles/tv/15.gif\" class=\"smile\" alt=\"(bgm38)\" />"
     )
   }
 


### PR DESCRIPTION
## What changed

Adds an optional mirror root domain setting under Network. It is empty by default, keeps the official Bangumi domains unless the user fills it in, and now opens a dedicated sheet for editing, normalized saving, effective domain previews, and the use-at-your-own-risk warning before routing login, requests, images, BBCode-generated links, and mirror share links through the configured mirror.

The app centralizes Bangumi domain construction in `BangumiURL` / `BangumiDomains`, covering the domains this app actually uses: the main site, `next`, and `lain`. Settings now display mirror-aware auth/share hosts, and Share Domain includes a Mirror option so generated share links can use the configured mirror root.

Generated BBCode subject, user, photo, and smiley URLs use the same configured domains, while user-provided `[url]` and `[img]` values stay unchanged.

Closes #146.

## Validation

- `git diff --check`
- `make build`
