### PR TITLE
fix(settings): address mirror domain review feedback

### DIFF
--- a/App/Client/BangumiURL.swift
+++ b/App/Client/BangumiURL.swift
@@ -26,6 +26,10 @@ enum BangumiURL {
     domains.nextURL(path: path)
   }
 
+  static nonisolated func officialNext(path: String = "") -> URL {
+    BangumiDomains.official.nextURL(path: path)
+  }
+
   static nonisolated func auth(path: String = "") -> URL {
     switch AppConfig.authDomain {
     case .origin:
@@ -69,8 +73,17 @@ enum BangumiURL {
       return rawValue
     }
 
-    components.host = domains.image
+    guard let imageHost = BangumiDomains.hostAndPort(from: domains.image) else {
+      return rawValue
+    }
+
+    components.host = imageHost.host
+    components.port = imageHost.port
     return components.url?.absoluteString ?? rawValue
+  }
+
+  static nonisolated func isMainURL(_ url: URL) -> Bool {
+    BangumiDomains.normalizedDomain(for: url.host, port: url.port) == domains.main
   }
 
   private static nonisolated var mirrorRootDomain: String {

--- a/App/Components/TurnstileView.swift
+++ b/App/Components/TurnstileView.swift
@@ -51,7 +51,7 @@ struct TrunstileView: UIViewRepresentable {
     webView.scrollView.isScrollEnabled = false
     webView.loadHTMLString(
       turnstileHTML,
-      baseURL: BangumiURL.next(path: "/turnstile")
+      baseURL: BangumiURL.officialNext(path: "/turnstile")
     )
     return webView
   }

--- a/App/Helpers/Navigation.swift
+++ b/App/Helpers/Navigation.swift
@@ -262,12 +262,12 @@ func handleChiiURL(_ url: URL, _ nav: Binding<NavigationPath>) -> Bool {
 
 @MainActor
 func handleHTTPURL(_ url: URL, _ nav: Binding<NavigationPath>) -> Bool {
-  switch url.host {
-  case "bgm.tv", "bangumi.tv", "chii.in":
+  let officialHosts = ["bgm.tv", "bangumi.tv", "chii.in"]
+  if let host = url.host, officialHosts.contains(host) || BangumiURL.isMainURL(url) {
     return handleBangumiURL(url, nav)
-  default:
-    return false
   }
+
+  return false
 }
 
 @MainActor

--- a/BBCode/Sources/BBCode/BangumiDomains.swift
+++ b/BBCode/Sources/BBCode/BangumiDomains.swift
@@ -37,6 +37,30 @@ public struct BangumiDomains: Hashable, Sendable {
     normalizedDomain(rawValue)
   }
 
+  public static func normalizedDomain(for host: String?, port: Int?) -> String? {
+    guard let host, !host.isEmpty else {
+      return nil
+    }
+
+    let normalizedHost = host.lowercased()
+    if let port {
+      return "\(normalizedHost):\(port)"
+    }
+    return normalizedHost
+  }
+
+  public static func hostAndPort(from domain: String) -> (host: String, port: Int?)? {
+    let candidate = domain.contains("://") ? domain : "https://\(domain)"
+    guard let components = URLComponents(string: candidate),
+      let host = components.host?.lowercased(),
+      !host.isEmpty
+    else {
+      return nil
+    }
+
+    return (host, components.port)
+  }
+
   public func mainURL(path: String = "") -> URL {
     url(domain: main, path: path)
   }

--- a/BBCode/Tests/BBCodeTests/HTMLTests.swift
+++ b/BBCode/Tests/BBCodeTests/HTMLTests.swift
@@ -19,6 +19,13 @@ class HTMLTests: XCTestCase {
     XCTAssertEqual(domains.next, "next.mirror.example")
   }
 
+  func testBangumiDomainsSplitHostAndPort() {
+    let domain = BangumiDomains.hostAndPort(from: "lain.mirror.example:8443")
+
+    XCTAssertEqual(domain?.host, "lain.mirror.example")
+    XCTAssertEqual(domain?.port, 8443)
+  }
+
   func testBold() {
     XCTAssertEqual(try BBCode().html("我是[b]粗体字[/b]"), "我是<strong>粗体字</strong>")
   }


### PR DESCRIPTION
## What changed

Addresses the actionable review feedback from #148 after the mirror domain support landed.

Turnstile now keeps its HTML base URL on the official `next.bgm.tv` origin so the existing Cloudflare site key can still issue tokens when a user configures a mirror. Mirror image URL rewriting now preserves `host:port` values instead of dropping back to `lain.bgm.tv`, and generated mirror Bangumi links can route back through in-app navigation.

## Validation

- `git diff --check`
- `make build`
