### PR TITLE
fix(image): bound thumbnail hit area

### DIFF
--- a/App/Components/Image+View/ImageView.swift
+++ b/App/Components/Image+View/ImageView.swift
@@ -37,6 +37,7 @@ struct ImageView: View {
             .geometryGroup()
             .frame(width: width, height: height, alignment: style.alignment)
             .applyClipShape(type: type, cornerRadius: style.cornerRadius)
+            .contentShape(Rectangle())
           } else if let aspectRatio = style.aspectRatio {
             AnimatedImage(url: imageURL)
               .onSuccess { _, _, _ in


### PR DESCRIPTION
## Summary

Fixed-size thumbnails can receive unusually wide images whose `scaledToFill` content extends beyond the visible frame. Visual clipping does not constrain SwiftUI hit testing, so the image navigation area could overlap an adjacent card.

Constrain the interaction shape to the displayed thumbnail frame. Taps in horizontal image rows now stay with the visible thumbnail even when the source image has an extreme aspect ratio.

## Validation

- `git diff --check`
- `make build`
