### PR TITLE
fix(ui): honor title preference in lists

### DIFF
--- a/App/Helpers/Timeline.swift
+++ b/App/Helpers/Timeline.swift
@@ -30,7 +30,7 @@ extension TimelineDTO {
     return text
   }
 
-  var desc: AttributedString {
+  func desc(with titlePreference: TitlePreference) -> AttributedString {
     var text = AttributedString("")
     if let user = self.user {
       text += user.nickname.withLink(user.link)
@@ -90,7 +90,7 @@ extension TimelineDTO {
     case .wiki:
       text += AttributedString("\(TimelineNewSubjectType(self.type).desc) ")
       if let subject = self.memo.wiki?.subject {
-        text += subject.name.withLink(subject.link)
+        text += subject.title(with: titlePreference).withLink(subject.link)
       } else {
         text += self.unknown("条目")
       }
@@ -98,7 +98,14 @@ extension TimelineDTO {
     case .subject:
       if self.batch {
         text += AttributedString("\(TimelineSubjectActionType(self.type).desc) ")
-        text += genBatch(self.memo.subject?.map(\.subject) ?? [])
+        let subjects =
+          self.memo.subject?.map {
+            LinkableDTO(
+              name: $0.subject.title(with: titlePreference),
+              link: $0.subject.link
+            )
+          } ?? []
+        text += genBatch(subjects)
         let count = self.memo.subject?.count ?? 0
         var typeID = self.memo.subject?.first?.subject.type.rawValue ?? 0
         if typeID == 0 {
@@ -108,7 +115,7 @@ extension TimelineDTO {
       } else {
         text += AttributedString("\(TimelineSubjectActionType(self.type).desc) ")
         if let collect = self.memo.subject?.first {
-          text += collect.subject.name.withLink(collect.subject.link)
+          text += collect.subject.title(with: titlePreference).withLink(collect.subject.link)
         } else {
           text += self.unknown("条目")
         }
@@ -120,7 +127,7 @@ extension TimelineDTO {
         if let batch = self.memo.progress?.batch {
           if batch.subject.type == .book {
             text += AttributedString("读过 ")
-            text += batch.subject.name.withLink(batch.subject.link)
+            text += batch.subject.title(with: titlePreference).withLink(batch.subject.link)
             if let volsUpdate = batch.volsUpdate, volsUpdate > 0 {
               text += AttributedString(" 第\(volsUpdate) 卷")
             }
@@ -129,7 +136,7 @@ extension TimelineDTO {
             }
           } else {
             text += AttributedString("完成了 ")
-            text += batch.subject.name.withLink(batch.subject.link)
+            text += batch.subject.title(with: titlePreference).withLink(batch.subject.link)
             text += AttributedString(" \(batch.epsUpdate ?? 0) of \(batch.epsTotal) 话")
           }
         } else {
@@ -138,7 +145,7 @@ extension TimelineDTO {
       case 1, 2, 3:
         if let episode = self.memo.progress?.single?.episode {
           text += AttributedString("\(EpisodeCollectionType(self.type).description) ")
-          text += episode.title(with: .original).withLink(episode.link)
+          text += episode.title(with: titlePreference).withLink(episode.link)
         } else {
           text += self.unknown("剧集")
         }
@@ -178,11 +185,11 @@ extension TimelineDTO {
         case 0:
           if let character = mono.characters.first {
             text += AttributedString("创建了新角色 ")
-            text += character.name.withLink(character.link)
+            text += character.title(with: titlePreference).withLink(character.link)
           }
           if let person = mono.persons.first {
             text += AttributedString("创建了新人物 ")
-            text += person.name.withLink(person.link)
+            text += person.title(with: titlePreference).withLink(person.link)
           }
         case 1:
           text += AttributedString("收藏了 ")
@@ -190,10 +197,18 @@ extension TimelineDTO {
             if mono.characters.count + mono.persons.count > 0 {
               var items: [LinkableDTO] = []
               for character in mono.characters {
-                items.append(LinkableDTO(name: character.name, link: character.link))
+                items.append(
+                  LinkableDTO(
+                    name: character.title(with: titlePreference),
+                    link: character.link
+                  ))
               }
               for person in mono.persons {
-                items.append(LinkableDTO(name: person.name, link: person.link))
+                items.append(
+                  LinkableDTO(
+                    name: person.title(with: titlePreference),
+                    link: person.link
+                  ))
               }
               text += genBatch(items)
               if mono.persons.count > 0 {
@@ -207,10 +222,10 @@ extension TimelineDTO {
           } else {
             if let character = mono.characters.first {
               text += AttributedString("角色 ")
-              text += character.name.withLink(character.link)
+              text += character.title(with: titlePreference).withLink(character.link)
             } else if let person = mono.persons.first {
               text += AttributedString("人物 ")
-              text += person.name.withLink(person.link)
+              text += person.title(with: titlePreference).withLink(person.link)
             } else {
               text += self.unknown("人物")
             }

--- a/App/Views/Character/CharacterCastItemView.swift
+++ b/App/Views/Character/CharacterCastItemView.swift
@@ -18,10 +18,6 @@ struct CharacterCastItemView: View {
 
         VStack(alignment: .leading) {
           Text(item.subject.title(with: titlePreference).withLink(item.subject.link))
-          if let subtitle = item.subject.subtitle(with: titlePreference) {
-            Text(subtitle)
-              .foregroundStyle(.secondary)
-          }
           Label(item.subject.type.description, systemImage: item.subject.type.icon)
             .foregroundStyle(.secondary)
           Text(item.subject.info ?? "")
@@ -38,10 +34,6 @@ struct CharacterCastItemView: View {
             HStack(alignment: .top) {
               VStack(alignment: .trailing, spacing: 2) {
                 Text(cast.person.title(with: titlePreference).withLink(cast.person.link))
-                if let subtitle = cast.person.subtitle(with: titlePreference) {
-                  Text(subtitle)
-                    .foregroundStyle(.secondary)
-                }
                 HStack(spacing: 4) {
                   BorderView {
                     Text(cast.relation.description).font(.caption)

--- a/App/Views/Character/CharacterLargeRowView.swift
+++ b/App/Views/Character/CharacterLargeRowView.swift
@@ -17,12 +17,6 @@ struct CharacterLargeRowView: View {
         Text(character.title(with: titlePreference))
           .font(.headline)
           .lineLimit(1)
-        if let subtitle = character.subtitle(with: titlePreference) {
-          Text(subtitle)
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
         Text(character.info)
           .font(.footnote)
           .foregroundStyle(.secondary)

--- a/App/Views/Character/CharacterRelationItemView.swift
+++ b/App/Views/Character/CharacterRelationItemView.swift
@@ -24,12 +24,6 @@ struct CharacterRelationItemView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text(item.character.title(with: titlePreference).withLink(item.character.link))
               .lineLimit(1)
-            if let subtitle = item.character.subtitle(with: titlePreference) {
-              Text(subtitle)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            }
 
             HStack(spacing: 4) {
               Label(relationText, systemImage: "link")

--- a/App/Views/Character/CharacterSmallView.swift
+++ b/App/Views/Character/CharacterSmallView.swift
@@ -1,16 +1,10 @@
 import SwiftUI
 
 struct CharacterSmallView: View {
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
+
   let character: SlimCharacterDTO
   let isCollected: Bool
-
-  var title: String {
-    if character.nameCN.isEmpty {
-      return character.name
-    } else {
-      return character.nameCN
-    }
-  }
 
   var body: some View {
     BorderView(color: .secondary.opacity(0.2), padding: 4, paddingRatio: 1, cornerRadius: 8) {
@@ -21,7 +15,7 @@ struct CharacterSmallView: View {
           .imageNSFW(character.nsfw)
           .imageCollectedStatus(isCollected)
         VStack(alignment: .leading) {
-          Text(title)
+          Text(character.title(with: titlePreference))
           if let info = character.info, !info.isEmpty {
             Text(info)
               .font(.footnote)

--- a/App/Views/Episode/EpisodeDiscView.swift
+++ b/App/Views/Episode/EpisodeDiscView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct EpisodeDiscView: View {
   let subjectId: Int
 
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
+
   @State private var refreshed: Bool = false
   @State private var episodes: [EpisodeDTO] = []
 
@@ -43,14 +45,9 @@ struct EpisodeDiscView: View {
   }
 
   func episodeLine(_ episode: EpisodeDTO) -> AttributedString {
-    var line = "\(Int(episode.sort)) \(episode.name)".withLink(episode.link)
+    var line =
+      "\(Int(episode.sort)) \(episode.title(with: titlePreference))".withLink(episode.link)
     line.font = .footnote
-    if !episode.nameCN.isEmpty {
-      var subline = AttributedString(" / \(episode.nameCN)")
-      subline.font = .caption
-      subline.foregroundColor = .secondary
-      line += subline
-    }
     return line
   }
 

--- a/App/Views/Episode/EpisodeDiscView.swift
+++ b/App/Views/Episode/EpisodeDiscView.swift
@@ -5,8 +5,6 @@ import SwiftUI
 struct EpisodeDiscView: View {
   let subjectId: Int
 
-  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
-
   @State private var refreshed: Bool = false
   @State private var episodes: [EpisodeDTO] = []
 
@@ -45,9 +43,14 @@ struct EpisodeDiscView: View {
   }
 
   func episodeLine(_ episode: EpisodeDTO) -> AttributedString {
-    var line =
-      "\(Int(episode.sort)) \(episode.title(with: titlePreference))".withLink(episode.link)
+    var line = "\(Int(episode.sort)) \(episode.name)".withLink(episode.link)
     line.font = .footnote
+    if !episode.nameCN.isEmpty {
+      var subline = AttributedString(" / \(episode.nameCN)")
+      subline.font = .caption
+      subline.foregroundColor = .secondary
+      line += subline
+    }
     return line
   }
 

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -97,12 +97,6 @@ struct IndexRelatedItemView: View {
                     .lineLimit(1)
                   Spacer(minLength: 0)
                 }
-                if let subtitle = character.subtitle(with: titlePreference) {
-                  Text(subtitle)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                }
                 Text(character.info ?? "")
                   .font(.footnote)
                   .foregroundStyle(.secondary)
@@ -144,20 +138,14 @@ struct IndexRelatedItemView: View {
                     .lineLimit(1)
                   Spacer(minLength: 0)
                 }
-                HStack(spacing: 2) {
-                  if let career = person.career, !career.isEmpty {
+                if let career = person.career, !career.isEmpty {
+                  HStack(spacing: 2) {
                     ForEach(career, id: \.self) { career in
                       BadgeView(background: .badge) {
                         Text(career.description)
                           .font(.caption)
                       }
                     }
-                  }
-                  if let subtitle = person.subtitle(with: titlePreference) {
-                    Text(subtitle)
-                      .font(.footnote)
-                      .foregroundStyle(.secondary)
-                      .lineLimit(1)
                   }
                 }
                 Text(person.info ?? "")

--- a/App/Views/Index/IndexRelatedSubjectItemView.swift
+++ b/App/Views/Index/IndexRelatedSubjectItemView.swift
@@ -45,12 +45,6 @@ struct IndexRelatedSubjectItemView: View {
           .lineLimit(1)
         Spacer(minLength: 0)
       }
-      if let subtitle = itemSubject.subtitle(with: titlePreference) {
-        Text(subtitle)
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
-      }
       Text(itemSubject.info ?? "")
         .font(.footnote)
         .foregroundStyle(.secondary)

--- a/App/Views/Person/PersonCastItemView.swift
+++ b/App/Views/Person/PersonCastItemView.swift
@@ -16,12 +16,6 @@ struct PersonCastItemView: View {
         VStack(alignment: .leading) {
           Text(item.character.title(with: titlePreference).withLink(item.character.link))
             .lineLimit(2)
-          if let subtitle = item.character.subtitle(with: titlePreference) {
-            Text(subtitle)
-              .lineLimit(1)
-              .font(.footnote)
-              .foregroundStyle(.secondary)
-          }
         }
 
         Spacer()
@@ -33,16 +27,10 @@ struct PersonCastItemView: View {
                 Text(relation.subject.title(with: titlePreference).withLink(relation.subject.link))
                   .lineLimit(1)
                 HStack {
-                  if let subtitle = relation.subject.subtitle(with: titlePreference) {
-                    Text(subtitle)
-                      .foregroundStyle(.secondary)
-                      .lineLimit(1)
-                  } else {
-                    Text(relation.subject.type.description)
-                      .font(.caption)
-                      .fixedSize(horizontal: true, vertical: true)
-                      .foregroundStyle(.secondary)
-                  }
+                  Text(relation.subject.type.description)
+                    .font(.caption)
+                    .fixedSize(horizontal: true, vertical: true)
+                    .foregroundStyle(.secondary)
                   BorderView {
                     Text(relation.type.description)
                       .font(.caption)

--- a/App/Views/Person/PersonLargeRowView.swift
+++ b/App/Views/Person/PersonLargeRowView.swift
@@ -17,12 +17,6 @@ struct PersonLargeRowView: View {
         Text(person.title(with: titlePreference))
           .font(.headline)
           .lineLimit(1)
-        if let subtitle = person.subtitle(with: titlePreference) {
-          Text(subtitle)
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
         Text(person.info)
           .font(.footnote)
           .foregroundStyle(.secondary)

--- a/App/Views/Person/PersonRelationItemView.swift
+++ b/App/Views/Person/PersonRelationItemView.swift
@@ -24,12 +24,6 @@ struct PersonRelationItemView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text(item.person.title(with: titlePreference).withLink(item.person.link))
               .lineLimit(1)
-            if let subtitle = item.person.subtitle(with: titlePreference) {
-              Text(subtitle)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            }
 
             HStack(spacing: 4) {
               Label(relationText, systemImage: "link")

--- a/App/Views/Person/PersonSmallView.swift
+++ b/App/Views/Person/PersonSmallView.swift
@@ -1,16 +1,10 @@
 import SwiftUI
 
 struct PersonSmallView: View {
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
+
   let person: SlimPersonDTO
   let isCollected: Bool
-
-  var title: String {
-    if person.nameCN.isEmpty {
-      return person.name
-    } else {
-      return person.nameCN
-    }
-  }
 
   var body: some View {
     BorderView(color: .secondary.opacity(0.2), padding: 4, paddingRatio: 1, cornerRadius: 8) {
@@ -21,7 +15,7 @@ struct PersonSmallView: View {
           .imageNSFW(person.nsfw)
           .imageCollectedStatus(isCollected)
         VStack(alignment: .leading) {
-          Text(title)
+          Text(person.title(with: titlePreference))
           if let info = person.info, !info.isEmpty {
             Text(info)
               .font(.footnote)

--- a/App/Views/Person/PersonWorksItemView.swift
+++ b/App/Views/Person/PersonWorksItemView.swift
@@ -18,12 +18,6 @@ struct PersonWorksItemView: View {
             Text(item.subject.title(with: titlePreference).withLink(item.subject.link))
               .font(.callout)
               .lineLimit(1)
-            if let subtitle = item.subject.subtitle(with: titlePreference) {
-              Text(subtitle)
-                .lineLimit(1)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-            }
             Label(item.subject.type.description, systemImage: item.subject.type.icon)
               .lineLimit(1)
               .font(.footnote)

--- a/App/Views/Subject/SubjectCardView.swift
+++ b/App/Views/Subject/SubjectCardView.swift
@@ -1,15 +1,9 @@
 import SwiftUI
 
 struct SubjectTinyView: View {
-  let subject: SlimSubjectDTO
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
-  var title: String {
-    if subject.nameCN.isEmpty {
-      return subject.name
-    } else {
-      return subject.nameCN
-    }
-  }
+  let subject: SlimSubjectDTO
 
   var body: some View {
     BorderView(color: .secondary.opacity(0.2), padding: 4, paddingRatio: 1, cornerRadius: 8) {
@@ -18,7 +12,7 @@ struct SubjectTinyView: View {
           .imageStyle(width: 32, height: 32)
           .imageType(.subject)
         VStack(alignment: .leading) {
-          Text(title)
+          Text(subject.title(with: titlePreference))
             .lineLimit(1)
         }
         Spacer(minLength: 0)
@@ -32,15 +26,9 @@ struct SubjectTinyView: View {
 }
 
 struct SubjectSmallView: View {
-  let subject: SlimSubjectDTO
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
-  var title: String {
-    if subject.nameCN.isEmpty {
-      return subject.name
-    } else {
-      return subject.nameCN
-    }
-  }
+  let subject: SlimSubjectDTO
 
   var ratingLine: Text {
     guard let rating = subject.rating else {
@@ -70,7 +58,7 @@ struct SubjectSmallView: View {
           .imageType(.subject)
           .imageNSFW(subject.nsfw)
         VStack(alignment: .leading) {
-          Text(title)
+          Text(subject.title(with: titlePreference))
           Text(subject.info ?? "")
             .font(.footnote)
             .foregroundStyle(.secondary)
@@ -284,12 +272,6 @@ struct SubjectCollectionRowContentView: View {
       VStack(alignment: .leading) {
         Text(subject.title(with: titlePreference).withLink(subject.link))
           .lineLimit(1)
-        if let subtitle = subject.subtitle(with: titlePreference) {
-          Text(subtitle)
-            .lineLimit(1)
-            .font(.caption)
-            .foregroundStyle(.secondary.opacity(0.8))
-        }
         Text(subject.info ?? "")
           .lineLimit(1)
           .font(.footnote)
@@ -389,11 +371,6 @@ struct SubjectCardView: View {
           Text(subject.title(with: titlePreference))
             .font(.headline)
             .lineLimit(1)
-          if let subtitle = subject.subtitle(with: titlePreference) {
-            Text(subtitle)
-              .font(.subheadline)
-              .lineLimit(1)
-          }
           Spacer()
           Text(subject.info ?? "")
             .font(.footnote)

--- a/App/Views/Subject/SubjectCharacterListView.swift
+++ b/App/Views/Subject/SubjectCharacterListView.swift
@@ -94,12 +94,6 @@ struct SubjectCharacterListView: View {
                       .foregroundStyle(.orange)
                   }
                 }
-                if let subtitle = item.character.subtitle(with: titlePreference) {
-                  Text(subtitle)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                }
               }
               HFlow {
                 let sortedCasts = item.casts.sorted {

--- a/App/Views/Subject/SubjectRelationListView.swift
+++ b/App/Views/Subject/SubjectRelationListView.swift
@@ -45,12 +45,6 @@ struct SubjectRelationListView: View {
                 VStack(alignment: .leading) {
                   Text(item.subject.title(with: titlePreference).withLink(item.subject.link))
                     .lineLimit(1)
-                  if let subtitle = item.subject.subtitle(with: titlePreference) {
-                    Text(subtitle)
-                      .font(.footnote)
-                      .foregroundStyle(.secondary)
-                      .lineLimit(1)
-                  }
                   Label(item.relation.cn, systemImage: item.subject.type.icon)
                     .font(.footnote)
                     .foregroundStyle(.secondary)

--- a/App/Views/Subject/SubjectSlimRowView.swift
+++ b/App/Views/Subject/SubjectSlimRowView.swift
@@ -37,13 +37,6 @@ struct SubjectSlimRowView: View {
           }
         }
 
-        if let subtitle = subject.subtitle(with: titlePreference) {
-          Text(subtitle)
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .lineLimit(1)
-        }
-
         if let info = subject.info, !info.isEmpty {
           Text(info)
             .font(.footnote)

--- a/App/Views/Subject/SubjectStaffListView.swift
+++ b/App/Views/Subject/SubjectStaffListView.swift
@@ -5,6 +5,8 @@ import SwiftUI
 struct SubjectStaffListView: View {
   let subjectId: Int
 
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
+
   @State private var collectionStatuses: [Int: Bool] = [:]
   @State private var loadedPersonIds: Set<Int> = []
 
@@ -55,12 +57,8 @@ struct SubjectStaffListView: View {
               .imageCollectedStatus(collectionStatuses[item.staff.id] ?? false)
               .imageNavLink(item.staff.link)
             VStack(alignment: .leading) {
-              Text(item.staff.name.withLink(item.staff.link))
+              Text(item.staff.title(with: titlePreference).withLink(item.staff.link))
                 .font(.callout)
-                .lineLimit(1)
-              Text(item.staff.nameCN)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
                 .lineLimit(1)
               HFlow {
                 ForEach(item.positions) { position in

--- a/App/Views/Timeline/TimelineItemView.swift
+++ b/App/Views/Timeline/TimelineItemView.swift
@@ -7,6 +7,7 @@ struct TimelineItemView: View {
 
   @AppStorage("isAuthenticated") var isAuthenticated: Bool = false
   @AppStorage("isolationMode") private var isolationMode = false
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   @State private var reactions: [ReactionDTO]
   @State private var showTime = false
@@ -63,7 +64,7 @@ struct TimelineItemView: View {
       VStack(alignment: .leading) {
         switch item.cat {
         case .daily:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
           switch item.type {
           case 2:
             if let users = item.memo.daily?.users, users.count > 0 {
@@ -98,13 +99,13 @@ struct TimelineItemView: View {
           }
 
         case .wiki:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
           if let subject = item.memo.wiki?.subject {
             SubjectSmallView(subject: subject)
           }
 
         case .subject:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
           if item.batch {
             let subjects = item.memo.subject?.map(\.subject).filter { $0.images != nil } ?? []
             ScrollView(.horizontal, showsIndicators: false) {
@@ -138,7 +139,7 @@ struct TimelineItemView: View {
           }
 
         case .progress:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
           switch item.type {
           case 0:
             if let subject = item.memo.progress?.batch?.subject {
@@ -152,7 +153,7 @@ struct TimelineItemView: View {
 
         case .status:
           if item.user != nil {
-            Text(item.desc).textSelection(.enabled)
+            Text(item.desc(with: titlePreference)).textSelection(.enabled)
           }
           switch item.type {
           case 0:
@@ -170,7 +171,7 @@ struct TimelineItemView: View {
           }
 
         case .mono:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
           if let mono = item.memo.mono, mono.characters.count + mono.persons.count > 0 {
             ScrollView(.horizontal, showsIndicators: false) {
               HStack {
@@ -192,7 +193,7 @@ struct TimelineItemView: View {
           }
 
         default:
-          Text(item.desc)
+          Text(item.desc(with: titlePreference))
         }
         if showReactions {
           switch item.cat {

--- a/App/Views/User/UserMonoListView.swift
+++ b/App/Views/User/UserMonoListView.swift
@@ -18,6 +18,7 @@ struct UserMonoListView: View {
   let user: SlimUserDTO
 
   @AppStorage("profile") var profile: Profile = Profile()
+  @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   @State private var type: MonoType = .character
 
@@ -71,10 +72,7 @@ struct UserMonoListView: View {
                   .imageType(.person)
                   .imageStyle(width: 60, height: 60, alignment: .top)
                 VStack(alignment: .leading) {
-                  Text(item.name.withLink(item.link))
-                  Text(item.nameCN)
-                    .foregroundStyle(.secondary)
-                    .font(.footnote)
+                  Text(item.title(with: titlePreference).withLink(item.link))
                 }
                 Spacer()
               }
@@ -88,10 +86,7 @@ struct UserMonoListView: View {
                   .imageType(.person)
                   .imageStyle(width: 60, height: 60, alignment: .top)
                 VStack(alignment: .leading) {
-                  Text(item.name.withLink(item.link))
-                  Text(item.nameCN)
-                    .foregroundStyle(.secondary)
-                    .font(.footnote)
+                  Text(item.title(with: titlePreference).withLink(item.link))
                 }
                 Spacer()
               }


### PR DESCRIPTION
## Summary

- respect the configured Chinese or original title preference across subject, character, and person list rows
- remove redundant alternate-name subtitles from list and card layouts
- keep explicit subtitle modes and detail-page name displays unchanged

## User experience

Lists now show a single preferred title instead of displaying both the original and Chinese names, reducing visual repetition and freeing vertical space.

## Validation

- `make build`
- `git diff --check`
