### PR TITLE
fix(bbcode): align mask, image, and list rendering

### DIFF
--- a/App/Components/PostDocumentRenderer.swift
+++ b/App/Components/PostDocumentRenderer.swift
@@ -412,14 +412,34 @@ actor PostDocumentRenderer {
           }
 
           .mask {
+            border: 1px solid #555;
             border-radius: 2px;
             background: #555;
             color: #555;
-            transition: color 0.18s linear;
+            padding: 0 5px;
+            position: relative;
+          }
+
+          .mask > .inner {
+            opacity: 0;
+            transition: opacity 0.18s linear;
+          }
+
+          .mask a {
+            color: #555 !important;
           }
 
           .mask.revealed {
-            color: #fff;
+            color: #fff !important;
+          }
+
+          .mask.revealed > .inner {
+            opacity: 1;
+            position: relative;
+          }
+
+          .mask.revealed a {
+            color: var(--link) !important;
           }
 
           .reactions {
@@ -555,9 +575,17 @@ actor PostDocumentRenderer {
 
               const mask = event.target.closest('.mask');
               if (mask) {
-                event.preventDefault();
-                mask.classList.toggle('revealed');
-                return;
+                if (!mask.classList.contains('revealed')) {
+                  event.preventDefault();
+                  mask.classList.add('revealed');
+                  return;
+                }
+
+                if (!event.target.closest('a')) {
+                  event.preventDefault();
+                  mask.classList.remove('revealed');
+                  return;
+                }
               }
 
               const image = event.target.closest('.post-content img');

--- a/App/Components/PostDocumentRenderer.swift
+++ b/App/Components/PostDocumentRenderer.swift
@@ -552,6 +552,21 @@ actor PostDocumentRenderer {
           (() => {
             const bridge = window.webkit?.messageHandlers?.postAction;
             const post = (payload) => bridge?.postMessage(payload);
+            const previewableImage = (target) => {
+              const image = target.closest('.post-content img');
+              if (
+                !image ||
+                image.closest('a') ||
+                image.classList.contains('smile') ||
+                image.classList.contains('smile-dynamic') ||
+                image.classList.contains('smile-musume') ||
+                image.classList.contains('smile-blake') ||
+                image.currentSrc.startsWith('data:')
+              ) {
+                return null;
+              }
+              return image;
+            };
 
             document.addEventListener('click', (event) => {
               const action = event.target.closest('[data-action]');
@@ -574,6 +589,7 @@ actor PostDocumentRenderer {
               }
 
               const mask = event.target.closest('.mask');
+              const image = previewableImage(event.target);
               if (mask) {
                 if (!mask.classList.contains('revealed')) {
                   event.preventDefault();
@@ -581,23 +597,14 @@ actor PostDocumentRenderer {
                   return;
                 }
 
-                if (!event.target.closest('a')) {
+                if (!event.target.closest('a') && !image) {
                   event.preventDefault();
                   mask.classList.remove('revealed');
                   return;
                 }
               }
 
-              const image = event.target.closest('.post-content img');
-              if (
-                image &&
-                !image.closest('a') &&
-                !image.classList.contains('smile') &&
-                !image.classList.contains('smile-dynamic') &&
-                !image.classList.contains('smile-musume') &&
-                !image.classList.contains('smile-blake') &&
-                !image.currentSrc.startsWith('data:')
-              ) {
+              if (image) {
                 event.preventDefault();
                 post({ action: 'previewImage', url: image.currentSrc });
               }
@@ -631,12 +638,41 @@ actor PostDocumentRenderer {
                 return;
               }
 
+              if (requestedWidth > 0 && requestedHeight > 0) {
+                const applyRequestedSize = () => {
+                  const sourceScale =
+                    image.naturalWidth > 0 && image.naturalHeight > 0
+                      ? Math.min(
+                          image.naturalWidth / requestedWidth,
+                          image.naturalHeight / requestedHeight,
+                          1
+                        )
+                      : 1;
+                  const targetWidth = Math.max(1, Math.round(requestedWidth * sourceScale));
+
+                  image.style.width = `min(100%, ${targetWidth}px)`;
+                  image.style.height = 'auto';
+                  image.style.maxWidth = 'none';
+                  image.style.maxHeight = 'none';
+                  image.style.aspectRatio = `${requestedWidth} / ${requestedHeight}`;
+                };
+
+                applyRequestedSize();
+                if (!image.complete) {
+                  image.addEventListener('load', applyRequestedSize, { once: true });
+                }
+                return;
+              }
+
               image.style.width = 'auto';
               image.style.height = 'auto';
+              image.style.aspectRatio = '';
               image.style.maxWidth =
                 requestedWidth > 0 ? `min(100%, ${requestedWidth}px)` : '100%';
               if (requestedHeight > 0) {
                 image.style.maxHeight = `${requestedHeight}px`;
+              } else {
+                image.style.maxHeight = '';
               }
             });
           })();

--- a/App/Features/BBCode/BBCodeMediaDimensions.swift
+++ b/App/Features/BBCode/BBCodeMediaDimensions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct BBCodeMediaDimensions {
+  let width: Int
+  let height: Int
+
+  init?(rawValue: String) {
+    let values = rawValue.split(omittingEmptySubsequences: false) {
+      $0 == "," || $0 == "x" || $0 == "X"
+    }
+    guard values.count == 2,
+      let width = Int(values[0].trimmingCharacters(in: .whitespacesAndNewlines)),
+      let height = Int(values[1].trimmingCharacters(in: .whitespacesAndNewlines)),
+      (1...9999).contains(width),
+      (1...9999).contains(height)
+    else {
+      return nil
+    }
+
+    self.width = width
+    self.height = height
+  }
+}

--- a/App/Features/BBCode/Renders/HTML.swift
+++ b/App/Features/BBCode/Renders/HTML.swift
@@ -149,18 +149,22 @@ var bbcodeHTMLRenderers: [BBCodeTagType: BBCodeHTMLRender] {
       return html
     },
     .list: { (n: BBCodeNode, args: [String: Any]?) in
-      var html: String
-      if n.attr.isEmpty {
-        html = "<ul>"
-      } else {
-        html = "<ol>"
+      let openingTag: String
+      let closingTag: String
+      switch n.attr {
+      case "1":
+        openingTag = "<ol>"
+        closingTag = "</ol>"
+      case "a", "A":
+        openingTag = "<ol type=\"\(n.escapedAttr)\">"
+        closingTag = "</ol>"
+      default:
+        openingTag = "<ul>"
+        closingTag = "</ul>"
       }
+      var html = openingTag
       html.append(n.renderInnerHTML(args))
-      if n.attr.isEmpty {
-        html.append("</ul>")
-      } else {
-        html.append("</ol>")
-      }
+      html.append(closingTag)
       return html
     },
     .listitem: { (n: BBCodeNode, args: [String: Any]?) in
@@ -274,17 +278,12 @@ var bbcodeHTMLRenderers: [BBCodeTagType: BBCodeHTMLRender] {
         if n.attr.isEmpty {
           html =
             "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" />"
+        } else if let dimensions = BBCodeMediaDimensions(rawValue: n.attr) {
+          html =
+            "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" width=\"\(dimensions.width)\" height=\"\(dimensions.height)\" />"
         } else {
-          let values = n.attr.components(separatedBy: ",").compactMap { Int($0) }
-          if values.count == 2 && values[0] > 0 && values[0] <= 4096 && values[1] > 0
-            && values[1] <= 4096
-          {
-            html =
-              "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" width=\"\(values[0])\" height=\"\(values[1])\" />"
-          } else {
-            html =
-              "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\(n.escapedAttr)\" />"
-          }
+          html =
+            "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\(n.escapedAttr)\" />"
         }
         return html
       } else {
@@ -300,17 +299,12 @@ var bbcodeHTMLRenderers: [BBCodeTagType: BBCodeHTMLRender] {
         if n.attr.isEmpty {
           html =
             "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" />"
+        } else if let dimensions = BBCodeMediaDimensions(rawValue: n.attr) {
+          html =
+            "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" width=\"\(dimensions.width)\" height=\"\(dimensions.height)\" />"
         } else {
-          let values = n.attr.components(separatedBy: ",").compactMap { Int($0) }
-          if values.count == 2 && values[0] > 0 && values[0] <= 4096 && values[1] > 0
-            && values[1] <= 4096
-          {
-            html =
-              "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\" width=\"\(values[0])\" height=\"\(values[1])\" />"
-          } else {
-            html =
-              "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\(n.escapedAttr)\" />"
-          }
+          html =
+            "<img src=\"\(safeLink)\" rel=\"noreferrer\" referrerpolicy=\"no-referrer\" loading=\"lazy\" decoding=\"async\" alt=\"\(n.escapedAttr)\" />"
         }
         return html
       } else {
@@ -364,9 +358,9 @@ var bbcodeHTMLRenderers: [BBCodeTagType: BBCodeHTMLRender] {
       return html
     },
     .mask: { (n: BBCodeNode, args: [String: Any]?) in
-      var html: String = "<span class=\"mask\">"
+      var html: String = "<span class=\"mask\"><span class=\"inner\">"
       html.append(n.renderInnerHTML(args))
-      html.append("</span>")
+      html.append("</span></span>")
       return html
     },
     .ruby: { (n: BBCodeNode, args: [String: Any]?) in
@@ -467,12 +461,28 @@ func makeBBCodeHTMLDocument(
           span.mask {
             background-color: #555;
             color: #555;
+            border: 1px solid #555;
             border-radius: 2px;
-            box-shadow: #555 0 0 5px;
+            padding: 0 5px;
+            position: relative;
             -webkit-transition: all .5s linear;
           }
+          span.mask > .inner {
+            opacity: 0;
+            -webkit-transition: all .5s linear;
+          }
+          span.mask a {
+            color: #555 !important;
+          }
           span.mask:hover {
-            color: #FFF;
+            color: #FFF !important;
+          }
+          span.mask:hover > .inner {
+            opacity: 1;
+            position: relative;
+          }
+          span.mask:hover a {
+            color: #0084B4 !important;
           }
           pre code {
             border: 1px solid #EEE;

--- a/App/Features/BBCode/Renders/PreparedDocument.swift
+++ b/App/Features/BBCode/Renders/PreparedDocument.swift
@@ -68,6 +68,7 @@ private final class BBCodePreparedDocumentCache {
 
 struct BBCodePreparedListItem: Identifiable {
   let id: Int
+  let marker: String
   let blocks: [BBCodePreparedBlock]
 }
 
@@ -82,6 +83,7 @@ struct BBCodePreparedBlock: Identifiable {
   enum Payload {
     case text(NSAttributedString)
     case image(BBCodePreparedMedia)
+    case mask([BBCodePreparedBlock])
     case quote([BBCodePreparedBlock])
     case list([BBCodePreparedListItem])
   }
@@ -169,6 +171,55 @@ private struct BBCodeTextKitRenderer {
     }
   }
 
+  private enum ListMarkerStyle {
+    case unordered
+    case decimal
+    case lowercaseAlpha
+    case uppercaseAlpha
+
+    init(attribute: String) {
+      switch attribute {
+      case "1":
+        self = .decimal
+      case "a":
+        self = .lowercaseAlpha
+      case "A":
+        self = .uppercaseAlpha
+      default:
+        self = .unordered
+      }
+    }
+
+    func marker(for index: Int) -> String {
+      switch self {
+      case .unordered:
+        return "\u{2022}"
+      case .decimal:
+        return "\(index + 1)."
+      case .lowercaseAlpha:
+        return Self.alphabeticMarker(for: index, baseScalar: 97)
+      case .uppercaseAlpha:
+        return Self.alphabeticMarker(for: index, baseScalar: 65)
+      }
+    }
+
+    private static func alphabeticMarker(for index: Int, baseScalar: UInt32) -> String {
+      var value = index + 1
+      var marker = ""
+
+      while value > 0 {
+        value -= 1
+        guard let scalar = UnicodeScalar(baseScalar + UInt32(value % 26)) else {
+          return "\(index + 1)."
+        }
+        marker = scalar.description + marker
+        value /= 26
+      }
+
+      return marker + "."
+    }
+  }
+
   let textSize: CGFloat
   let baseFont: UIFont
   let linkColor: UIColor
@@ -245,7 +296,16 @@ private struct BBCodeTextKitRenderer {
       let itemSegments = collectListItemNodes(from: node.children).map {
         renderSegments(children: $0)
       }
-      return [.block(.list(makeListItems(from: itemSegments)))]
+      return [
+        .block(
+          .list(
+            makeListItems(
+              from: itemSegments,
+              markerStyle: ListMarkerStyle(attribute: node.attr)
+            )
+          )
+        )
+      ]
     case .root, .float:
       return renderSegments(children: node.children)
     case .center, .left, .right, .align, .code:
@@ -382,9 +442,7 @@ private struct BBCodeTextKitRenderer {
         }
       }
     case .mask:
-      return mapTextSegments(segments) { attributed in
-        applyAttribute(.bbcodeMask, value: true, to: attributed)
-      }
+      return [.block(.mask(makeBlocks(from: segments)))]
     default:
       return segments
     }
@@ -465,6 +523,15 @@ private struct BBCodeTextKitRenderer {
           alignment: alignment
         )
       )
+    case .mask(let blocks):
+      return .mask(
+        blocks.map { block in
+          BBCodePreparedBlock(
+            id: block.id,
+            payload: alignedPayload(block.payload, alignment: alignment)
+          )
+        }
+      )
     case .quote, .list, .text:
       return payload
     }
@@ -484,6 +551,10 @@ private struct BBCodeTextKitRenderer {
           alignment: media.alignment
         )
       )
+    case .mask(let blocks):
+      return .mask(blocks.map { block in
+        BBCodePreparedBlock(id: block.id, payload: linkedPayload(block.payload, url: url))
+      })
     case .quote(let blocks):
       return .quote(blocks.map { block in
         BBCodePreparedBlock(id: block.id, payload: linkedPayload(block.payload, url: url))
@@ -492,6 +563,7 @@ private struct BBCodeTextKitRenderer {
       return .list(items.map { item in
         BBCodePreparedListItem(
           id: item.id,
+          marker: item.marker,
           blocks: item.blocks.map { block in
             BBCodePreparedBlock(id: block.id, payload: linkedPayload(block.payload, url: url))
           }
@@ -568,14 +640,21 @@ private struct BBCodeTextKitRenderer {
     return normalized
   }
 
-  private func makeListItems(from itemSegments: [[RenderedSegment]]) -> [BBCodePreparedListItem] {
+  private func makeListItems(
+    from itemSegments: [[RenderedSegment]],
+    markerStyle: ListMarkerStyle
+  ) -> [BBCodePreparedListItem] {
     itemSegments.enumerated().compactMap { index, segments in
       let blocks = makeBlocks(from: segments)
       guard !blocks.isEmpty else {
         return nil
       }
 
-      return BBCodePreparedListItem(id: index, blocks: blocks)
+      return BBCodePreparedListItem(
+        id: index,
+        marker: markerStyle.marker(for: index),
+        blocks: blocks
+      )
     }
   }
 
@@ -714,16 +793,11 @@ private struct BBCodeTextKitRenderer {
   }
 
   private func parsedMediaSize(from rawValue: String) -> CGSize? {
-    let values =
-      rawValue
-      .split(separator: ",")
-      .compactMap { Int($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
-
-    guard values.count == 2, values[0] > 0, values[1] > 0 else {
+    guard let dimensions = BBCodeMediaDimensions(rawValue: rawValue) else {
       return nil
     }
 
-    return CGSize(width: values[0], height: values[1])
+    return CGSize(width: dimensions.width, height: dimensions.height)
   }
 
   private func renderChildren(_ children: [BBCodeNode]) -> NSMutableAttributedString {

--- a/App/Features/BBCode/Tags.swift
+++ b/App/Features/BBCode/Tags.swift
@@ -284,7 +284,7 @@ let bbcodeTagDefinitions: [BBCodeTagInfo] = [
       allowedChildren: [
         .list, .listitem, .br, .url, .subject, .user,
       ] + BBCodeTagType.unsupported + BBCodeTagType.textStyle,
-      allowAttr: false,
+      allowAttr: true,
       isBlock: true
     )
   ),
@@ -323,7 +323,7 @@ let bbcodeTagDefinitions: [BBCodeTagInfo] = [
     BBCodeTagDescription(
       tagNeeded: true, isSelfClosing: false,
       allowedChildren: [
-        .image, .br,
+        .image, .mask, .br,
       ] + BBCodeTagType.unsupported + BBCodeTagType.textStyle,
       allowAttr: true, isBlock: false
     )
@@ -413,7 +413,7 @@ let bbcodeTagDefinitions: [BBCodeTagInfo] = [
     BBCodeTagDescription(
       tagNeeded: true, isSelfClosing: false,
       allowedChildren: [
-        .br, .subject, .user,
+        .br, .url, .image, .photo, .bgm, .bmo, .subject, .user,
       ] + BBCodeTagType.unsupported + BBCodeTagType.textStyle,
       allowAttr: false,
       isBlock: true

--- a/App/Features/BBCode/Views/BBCodeUIKitView.swift
+++ b/App/Features/BBCode/Views/BBCodeUIKitView.swift
@@ -89,6 +89,8 @@ final class BBCodeBlocksContainerView: UIView {
       return BBCodeTextBlockView(attributedText: attributedText)
     case .image(let media):
       return BBCodeMediaBlockView(media: media)
+    case .mask(let blocks):
+      return BBCodeMaskBlockView(blocks: blocks)
     case .quote(let blocks):
       return BBCodeQuoteBlockView(blocks: blocks)
     case .list(let items):
@@ -132,7 +134,6 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
   }
 
   private let hiddenMaskColor = UIColor(white: 0.35, alpha: 1)
-  private let revealedMaskTextColor = UIColor.white
   private let maskLinkURL = URL(string: "bbcode-mask://toggle")!
   private let baseAttributedText: NSAttributedString
   var openURLHandler: ((URL) -> Void)?
@@ -211,14 +212,14 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
         return
       }
 
-      renderedText.addAttribute(.link, value: maskLinkURL, range: range)
+      let maskRange = MaskRangeKey(range)
+      let isRevealed = revealedMasks.contains(maskRange)
+      applyLinks(in: range, isRevealed: isRevealed, to: renderedText)
       renderedText.addAttribute(.backgroundColor, value: hiddenMaskColor, range: range)
-      renderedText.addAttribute(
-        .foregroundColor,
-        value: revealedMasks.contains(MaskRangeKey(range))
-          ? revealedMaskTextColor : hiddenMaskColor,
-        range: range
-      )
+      if !isRevealed {
+        renderedText.addAttribute(.foregroundColor, value: hiddenMaskColor, range: range)
+        hideAttachments(in: range, in: renderedText)
+      }
     }
 
     if animated {
@@ -233,6 +234,52 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
       super.attributedText = renderedText
     }
     updateAnimatedSmileyOverlays(forceReload: forceReload)
+  }
+
+  private func applyLinks(
+    in range: NSRange,
+    isRevealed: Bool,
+    to renderedText: NSMutableAttributedString
+  ) {
+    guard isRevealed else {
+      renderedText.addAttribute(.link, value: maskLinkURL, range: range)
+      return
+    }
+
+    baseAttributedText.enumerateAttribute(.link, in: range) { value, linkRange, _ in
+      renderedText.addAttribute(
+        .link,
+        value: value ?? maskLinkURL,
+        range: linkRange
+      )
+    }
+  }
+
+  private func hideAttachments(in range: NSRange, in renderedText: NSMutableAttributedString) {
+    baseAttributedText.enumerateAttribute(.attachment, in: range) { value, attachmentRange, _ in
+      guard let attachment = value as? NSTextAttachment else {
+        return
+      }
+
+      let renderedSize: CGSize
+      if let smiley = attachment as? BBCodeSmileyTextAttachment {
+        renderedSize = smiley.renderedSize
+      } else if let image = attachment as? BBCodeInlineImageTextAttachment {
+        renderedSize = image.renderedSize
+      } else {
+        renderedSize = attachment.bounds.size
+      }
+
+      guard renderedSize.width > 0, renderedSize.height > 0 else {
+        return
+      }
+
+      renderedText.addAttribute(
+        .attachment,
+        value: BBCodeHiddenTextAttachment(renderedSize: renderedSize),
+        range: attachmentRange
+      )
+    }
   }
 
   private func updateAnimatedSmileyOverlays(forceReload: Bool = false) {
@@ -360,6 +407,42 @@ private final class BBCodeAnimatedSmileyImageView: SDAnimatedImageView {
   var resourcePath: String?
 }
 
+private final class BBCodeHiddenTextAttachment: NSTextAttachment {
+  private let renderedSize: CGSize
+
+  init(renderedSize: CGSize) {
+    self.renderedSize = renderedSize
+    super.init(data: nil, ofType: nil)
+
+    let format = UIGraphicsImageRendererFormat.default()
+    format.opaque = false
+    self.image = UIGraphicsImageRenderer(size: renderedSize, format: format).image { _ in }
+    self.bounds = CGRect(origin: .zero, size: renderedSize)
+    allowsTextAttachmentView = false
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func attachmentBounds(
+    for attributes: [NSAttributedString.Key: Any],
+    location: any NSTextLocation,
+    textContainer: NSTextContainer?,
+    proposedLineFragment: CGRect,
+    position: CGPoint
+  ) -> CGRect {
+    let font = (attributes[.font] as? UIFont) ?? .systemFont(ofSize: 16)
+    return CGRect(
+      x: 0,
+      y: BBCodeLayoutMetrics.inlineAttachmentVerticalOffset(for: renderedSize.height, font: font),
+      width: renderedSize.width,
+      height: renderedSize.height
+    )
+  }
+}
+
 private final class BBCodeMediaBlockView: UIView {
   private let media: BBCodePreparedMedia
   private let imageView = SDAnimatedImageView()
@@ -376,7 +459,7 @@ private final class BBCodeMediaBlockView: UIView {
     self.media = media
 
     imageView.translatesAutoresizingMaskIntoConstraints = false
-    imageView.contentMode = .scaleAspectFit
+    imageView.contentMode = media.constrainedSize == nil ? .scaleAspectFit : .scaleToFill
     imageView.clipsToBounds = false
     imageView.sd_imageIndicator = SDWebImageActivityIndicator.gray
 
@@ -536,16 +619,29 @@ private final class BBCodeMediaBlockView: UIView {
     let fallbackSide = min(maxWidth, 160)
     let sourceSize = sourceSize ?? CGSize(width: fallbackSide, height: fallbackSide)
 
-    let maxDisplayWidth = min(maxWidth, media.constrainedSize?.width ?? maxWidth)
-    let maxDisplayHeight = media.constrainedSize?.height ?? CGFloat.greatestFiniteMagnitude
+    if let constrainedSize = media.constrainedSize {
+      let availableScale = min(maxWidth / constrainedSize.width, 1)
+      let sourceScale =
+        self.sourceSize.map {
+          min(
+            $0.width / constrainedSize.width,
+            $0.height / constrainedSize.height,
+            1
+          )
+        } ?? 1
+      let scale = min(availableScale, sourceScale)
 
-    guard sourceSize.width > 0, sourceSize.height > 0 else {
-      return CGSize(width: maxDisplayWidth, height: min(maxDisplayWidth, 120))
+      return CGSize(
+        width: max(1, round(constrainedSize.width * scale)),
+        height: max(1, round(constrainedSize.height * scale))
+      )
     }
 
-    let widthRatio = maxDisplayWidth / sourceSize.width
-    let heightRatio = maxDisplayHeight / sourceSize.height
-    let scale = min(widthRatio, heightRatio, 1)
+    guard sourceSize.width > 0, sourceSize.height > 0 else {
+      return CGSize(width: maxWidth, height: min(maxWidth, 120))
+    }
+
+    let scale = min(maxWidth / sourceSize.width, 1)
 
     return CGSize(
       width: max(1, round(sourceSize.width * scale)),
@@ -604,6 +700,69 @@ private final class BBCodeMediaBlockView: UIView {
     controller.modalTransitionStyle = .crossDissolve
     controller.view.backgroundColor = .clear
     presenter.present(controller, animated: true)
+  }
+}
+
+private final class BBCodeMaskBlockView: UIView {
+  private let contentView = BBCodeBlocksContainerView()
+  private let coverButton = UIButton(type: .custom)
+
+  init(blocks: [BBCodePreparedBlock]) {
+    super.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+    backgroundColor = UIColor(white: 0.35, alpha: 1)
+    layer.cornerRadius = 2
+    clipsToBounds = true
+    directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 4,
+      leading: 5,
+      bottom: 4,
+      trailing: 5
+    )
+    setContentCompressionResistancePriority(.required, for: .vertical)
+    setContentHuggingPriority(.required, for: .vertical)
+
+    contentView.update(blocks: blocks)
+    contentView.alpha = 0
+    contentView.accessibilityElementsHidden = true
+
+    coverButton.translatesAutoresizingMaskIntoConstraints = false
+    coverButton.backgroundColor = .clear
+    coverButton.accessibilityLabel = "Reveal hidden content"
+    coverButton.addTarget(self, action: #selector(reveal), for: .touchUpInside)
+
+    addSubview(contentView)
+    addSubview(coverButton)
+    NSLayoutConstraint.activate([
+      contentView.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+      contentView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+      contentView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+      contentView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
+
+      coverButton.topAnchor.constraint(equalTo: topAnchor),
+      coverButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+      coverButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+      coverButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  @objc private func reveal() {
+    contentView.accessibilityElementsHidden = false
+    UIView.animate(
+      withDuration: 0.18,
+      animations: {
+        self.contentView.alpha = 1
+        self.coverButton.alpha = 0
+      },
+      completion: { _ in
+        self.coverButton.isHidden = true
+      }
+    )
   }
 }
 
@@ -697,8 +856,24 @@ private final class BBCodeListBlockView: UIView {
     stackView.spacing = 0
     stackView.translatesAutoresizingMaskIntoConstraints = false
 
+    let markerFont = UIFont.preferredFont(forTextStyle: .body)
+    let markerWidths =
+      items
+      .map {
+        ceil(
+          ($0.marker as NSString).size(withAttributes: [.font: markerFont]).width
+        )
+      }
+    let markerWidth = max(10, markerWidths.max() ?? 0)
+
     for item in items {
-      stackView.addArrangedSubview(BBCodeListItemView(item: item))
+      stackView.addArrangedSubview(
+        BBCodeListItemView(
+          item: item,
+          markerFont: markerFont,
+          markerWidth: markerWidth
+        )
+      )
     }
 
     addSubview(stackView)
@@ -717,7 +892,7 @@ private final class BBCodeListBlockView: UIView {
 }
 
 private final class BBCodeListItemView: UIView {
-  init(item: BBCodePreparedListItem) {
+  init(item: BBCodePreparedListItem, markerFont: UIFont, markerWidth: CGFloat) {
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
     backgroundColor = .clear
@@ -725,7 +900,9 @@ private final class BBCodeListItemView: UIView {
 
     let bulletLabel = UILabel()
     bulletLabel.translatesAutoresizingMaskIntoConstraints = false
-    bulletLabel.text = "\u{2022}"
+    bulletLabel.text = item.marker
+    bulletLabel.font = markerFont
+    bulletLabel.textAlignment = .right
     bulletLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
     bulletLabel.setContentHuggingPriority(.required, for: .horizontal)
 
@@ -744,7 +921,7 @@ private final class BBCodeListItemView: UIView {
       stackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
       stackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
       stackView.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
-      bulletLabel.widthAnchor.constraint(equalToConstant: 10),
+      bulletLabel.widthAnchor.constraint(equalToConstant: markerWidth),
     ])
   }
 

--- a/App/Features/BBCode/Views/BBCodeUIKitView.swift
+++ b/App/Features/BBCode/Views/BBCodeUIKitView.swift
@@ -134,6 +134,7 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
   }
 
   private let hiddenMaskColor = UIColor(white: 0.35, alpha: 1)
+  private let revealedMaskTextColor = UIColor.white
   private let maskLinkURL = URL(string: "bbcode-mask://toggle")!
   private let baseAttributedText: NSAttributedString
   var openURLHandler: ((URL) -> Void)?
@@ -214,12 +215,14 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
 
       let maskRange = MaskRangeKey(range)
       let isRevealed = revealedMasks.contains(maskRange)
-      applyLinks(in: range, isRevealed: isRevealed, to: renderedText)
       renderedText.addAttribute(.backgroundColor, value: hiddenMaskColor, range: range)
-      if !isRevealed {
+      if isRevealed {
+        renderedText.addAttribute(.foregroundColor, value: revealedMaskTextColor, range: range)
+      } else {
         renderedText.addAttribute(.foregroundColor, value: hiddenMaskColor, range: range)
         hideAttachments(in: range, in: renderedText)
       }
+      applyLinks(in: range, isRevealed: isRevealed, to: renderedText)
     }
 
     if animated {
@@ -252,6 +255,17 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
         value: value ?? maskLinkURL,
         range: linkRange
       )
+      guard value != nil else {
+        return
+      }
+
+      baseAttributedText.enumerateAttribute(.foregroundColor, in: linkRange) {
+        color, colorRange, _ in
+        guard let color else {
+          return
+        }
+        renderedText.addAttribute(.foregroundColor, value: color, range: colorRange)
+      }
     }
   }
 
@@ -387,7 +401,17 @@ private final class BBCodeTextBlockView: UITextView, UITextViewDelegate {
     }
 
     if url.scheme == maskLinkURL.scheme {
-      let maskRange = MaskRangeKey(textItem.range)
+      var enclosingRange = NSRange()
+      guard
+        baseAttributedText.attribute(
+          .bbcodeMask,
+          at: textItem.range.location,
+          effectiveRange: &enclosingRange
+        ) != nil
+      else {
+        return defaultAction
+      }
+      let maskRange = MaskRangeKey(enclosingRange)
       return UIAction { [weak self] _ in
         self?.toggleMask(maskRange)
       }


### PR DESCRIPTION
## What changed

- Align mask parsing and reveal behavior with the web renderer, including nested links, block images, and inline sticker attachments.
- Share source-compatible image dimension parsing across native and HTML rendering, and honor explicit width and height without upscaling small assets.
- Render numeric, lowercase, and uppercase BBCode lists with stable marker alignment.

## User experience

Masked links and media stay hidden until revealed, then remain interactive. Sized images use the requested aspect ratio, and `[list=1]`, `[list=a]`, and `[list=A]` no longer appear as raw BBCode.

## Validation

- `make build`
- `git diff --check`
- Simulator preview verification for mask reveal, dynamic attachments, 4:3 image sizing, and all three list marker styles
