### PR TITLE
fix(ui): make collection status badges opaque

### DIFF
--- a/App/Components/Image+View/ImageBadge+View.swift
+++ b/App/Components/Image+View/ImageBadge+View.swift
@@ -74,7 +74,7 @@ private struct ImageStatusBadge: View {
       .font(.system(size: iconSize, weight: .bold))
       .foregroundStyle(.white)
       .frame(width: size, height: size)
-      .background(background.opacity(0.9))
+      .background(background)
       .clipShape(Circle())
       .overlay {
         Circle()


### PR DESCRIPTION
## Summary

Make image collection status badge backgrounds fully opaque so the underlying cover artwork no longer shows through.

The shared badge keeps its existing color, icon, sizing, placement, and border.

## Validation

- `make build`
