### PR TITLE
feat: show episode discussion count in menu

### DIFF
--- a/App/Views/Episode/EpisodeUpdateMenu.swift
+++ b/App/Views/Episode/EpisodeUpdateMenu.swift
@@ -74,7 +74,7 @@ struct EpisodeUpdateMenu: View {
       if isolationMode {
         Label("详情...", systemImage: "info")
       } else {
-        Label("参与讨论...", systemImage: "bubble")
+        Label("讨论 (+\(episode.comment))", systemImage: "bubble")
       }
     }
   }


### PR DESCRIPTION
## Summary

Show the episode discussion count directly in the episode action menu, such as `Discussion (+123)`.

Keep the existing detail label in isolation mode, where discussion content is unavailable.

## Validation

- `make build`
