### PR TITLE
feat: add floating post navigation controls

### DIFF
--- a/App/Components/PostActionOverlay.swift
+++ b/App/Components/PostActionOverlay.swift
@@ -34,7 +34,14 @@ private enum PostReactionPickerLayout {
 private enum PostMoreMenuLayout {
   static let width: CGFloat = 148
   static let itemHeight: CGFloat = 44
-  static let spacing: CGFloat = 8
+
+  static var spacing: CGFloat {
+    if #available(iOS 26.0, *) {
+      0
+    } else {
+      4
+    }
+  }
 
   static func height(for itemCount: Int) -> CGFloat {
     CGFloat(itemCount) * itemHeight
@@ -86,6 +93,23 @@ extension View {
         shadowY: shadowY
       )
     )
+  }
+
+  @ViewBuilder
+  fileprivate func adaptivePostFloatingSurface<Surface: Shape>(
+    _ surface: Surface,
+    shadowRadius: CGFloat,
+    shadowY: CGFloat
+  ) -> some View {
+    if #available(iOS 26.0, *) {
+      self.glassEffect(.regular, in: surface)
+    } else {
+      self.postFloatingSurface(
+        surface,
+        shadowRadius: shadowRadius,
+        shadowY: shadowY
+      )
+    }
   }
 }
 
@@ -300,7 +324,7 @@ private struct PostReactionPickerPanel: View {
       }
     }
     .padding(PostReactionPickerLayout.contentPadding)
-    .postFloatingSurface(
+    .adaptivePostFloatingSurface(
       RoundedRectangle(cornerRadius: 16, style: .continuous),
       shadowRadius: 16,
       shadowY: 7
@@ -398,16 +422,12 @@ private struct PostMoreMenuPanel: View {
           .frame(width: 20)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
-      .padding(.horizontal, 14)
-      .frame(height: PostMoreMenuLayout.itemHeight)
       .foregroundStyle(tint)
-      .postFloatingSurface(
-        RoundedRectangle(cornerRadius: 14, style: .continuous),
-        shadowRadius: 10,
-        shadowY: 4
-      )
     }
-    .buttonStyle(PostFloatingActionButtonStyle())
+    .controlSize(.regular)
+    .adaptiveButtonStyle(.bordered)
+    .adaptiveFlexibleButtonSizing()
+    .frame(height: PostMoreMenuLayout.itemHeight)
     .disabled(!isEnabled)
     .modifier(PostActionEntranceModifier(isVisible: isVisible, index: index))
   }
@@ -438,20 +458,6 @@ private struct PostReactionChoiceButtonStyle: ButtonStyle {
     configuration.label
       .scaleEffect(configuration.isPressed ? 0.88 : 1)
       .opacity(configuration.isPressed ? 0.72 : 1)
-      .animation(
-        .snappy(duration: 0.14, extraBounce: 0),
-        value: configuration.isPressed
-      )
-  }
-}
-
-private struct PostFloatingActionButtonStyle: ButtonStyle {
-  @Environment(\.isEnabled) private var isEnabled
-
-  func makeBody(configuration: Configuration) -> some View {
-    configuration.label
-      .scaleEffect(configuration.isPressed ? 0.94 : 1, anchor: .trailing)
-      .opacity(isEnabled ? (configuration.isPressed ? 0.72 : 1) : 0.38)
       .animation(
         .snappy(duration: 0.14, extraBounce: 0),
         value: configuration.isPressed

--- a/App/Components/PostDocumentNavigator.swift
+++ b/App/Components/PostDocumentNavigator.swift
@@ -237,14 +237,14 @@ private struct PostDocumentFloorNavigator: View {
         Spacer()
 
         Button {
-          onSelect(.top)
+          selectTop()
         } label: {
           Label("回到顶部", systemImage: "arrow.up.to.line")
             .labelStyle(.iconOnly)
         }
 
         Button {
-          onSelect(.bottom)
+          selectBottom()
         } label: {
           Label("跳到底部", systemImage: "arrow.down.to.line")
             .labelStyle(.iconOnly)
@@ -272,6 +272,16 @@ private struct PostDocumentFloorNavigator: View {
     let index = min(max(index, 0), items.count - 1)
     selectedIndex = Double(index)
     onSelect(.post(items[index].postID))
+  }
+
+  private func selectTop() {
+    selectedIndex = 0
+    onSelect(.top)
+  }
+
+  private func selectBottom() {
+    selectedIndex = Double(items.count - 1)
+    onSelect(.bottom)
   }
 
   private func selectCurrentItem() {

--- a/App/Components/PostDocumentNavigator.swift
+++ b/App/Components/PostDocumentNavigator.swift
@@ -1,0 +1,271 @@
+import SwiftUI
+
+struct PostDocumentNavigationItem: Hashable, Identifiable, Sendable {
+  let postID: Int
+  let floor: String
+
+  var id: Int {
+    postID
+  }
+}
+
+enum PostDocumentScrollTarget: Equatable, Sendable {
+  case top
+  case bottom
+  case post(Int)
+}
+
+struct PostDocumentScrollRequest: Equatable, Identifiable, Sendable {
+  let id = UUID()
+  let target: PostDocumentScrollTarget
+  let animated: Bool
+}
+
+struct PostDocumentViewportState: Equatable, Sendable {
+  let canScrollToTop: Bool
+  let visiblePostID: Int?
+
+  static let top = PostDocumentViewportState(
+    canScrollToTop: false,
+    visiblePostID: nil
+  )
+}
+
+struct PostDocumentFilterSortConfiguration {
+  let filterModes: [ReplyFilterMode]
+  let filterMode: Binding<ReplyFilterMode>
+  let sortOrder: Binding<ReplySortOrder>
+}
+
+struct PostDocumentNavigatorOverlay: View {
+  let items: [PostDocumentNavigationItem]
+  let visiblePostID: Int?
+  let controls: PostDocumentFilterSortConfiguration
+  let canScrollToTop: Bool
+  let onSelect: (PostDocumentScrollTarget) -> Void
+
+  @State private var showsFloorNavigator = false
+
+  private var visibleItem: PostDocumentNavigationItem? {
+    items.first { $0.postID == visiblePostID }
+  }
+
+  private var widestFloor: String {
+    items.map(\.floor).max { lhs, rhs in
+      lhs.count < rhs.count
+    } ?? "楼层"
+  }
+
+  var body: some View {
+    HStack(spacing: 8) {
+      PostDocumentFilterSortControls(configuration: controls)
+
+      if items.count > 1 {
+        Button {
+          showsFloorNavigator = true
+        } label: {
+          HStack(spacing: 4) {
+            Image(systemName: "list.number")
+            ZStack(alignment: .leading) {
+              Text("楼层")
+                .hidden()
+              Text(widestFloor)
+                .hidden()
+              Text(visibleItem?.floor ?? "楼层")
+            }
+            .monospacedDigit()
+          }
+        }
+        .adaptiveButtonStyle(.bordered)
+        .accessibilityHint("选择要跳转的楼层")
+        .popover(isPresented: $showsFloorNavigator) {
+          PostDocumentFloorNavigator(
+            items: items,
+            visiblePostID: visiblePostID,
+            onSelect: onSelect
+          )
+          .presentationCompactAdaptation(.sheet)
+        }
+      }
+
+      Button {
+        onSelect(.top)
+      } label: {
+        Label("回到顶部", systemImage: "arrow.up")
+          .labelStyle(.iconOnly)
+      }
+      .adaptiveButtonStyle(.borderedProminent)
+      .disabled(!canScrollToTop)
+    }
+  }
+}
+
+private struct PostDocumentFilterSortControls: View {
+  let filterModes: [ReplyFilterMode]
+  @Binding var filterMode: ReplyFilterMode
+  @Binding var sortOrder: ReplySortOrder
+
+  init(configuration: PostDocumentFilterSortConfiguration) {
+    filterModes = configuration.filterModes
+    _filterMode = configuration.filterMode
+    _sortOrder = configuration.sortOrder
+  }
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Menu {
+        Picker("筛选", selection: $filterMode) {
+          ForEach(filterModes, id: \.self) { mode in
+            Label(mode.description, systemImage: mode.icon).tag(mode)
+          }
+        }
+      } label: {
+        Label("筛选", systemImage: filterMode.icon)
+          .labelStyle(.iconOnly)
+      }
+      .adaptiveButtonStyle(.bordered)
+      .accessibilityValue(Text(filterMode.description))
+
+      Menu {
+        Picker("排序", selection: $sortOrder) {
+          ForEach(ReplySortOrder.allCases, id: \.self) { order in
+            Label(order.description, systemImage: order.icon).tag(order)
+          }
+        }
+      } label: {
+        Label("排序", systemImage: sortOrder.icon)
+          .labelStyle(.iconOnly)
+      }
+      .adaptiveButtonStyle(.bordered)
+      .accessibilityValue(Text(sortOrder.description))
+    }
+  }
+}
+
+private struct PostDocumentFloorNavigator: View {
+  let items: [PostDocumentNavigationItem]
+  let onSelect: (PostDocumentScrollTarget) -> Void
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var selectedIndex: Double
+
+  init(
+    items: [PostDocumentNavigationItem],
+    visiblePostID: Int?,
+    onSelect: @escaping (PostDocumentScrollTarget) -> Void
+  ) {
+    self.items = items
+    self.onSelect = onSelect
+    let initialIndex =
+      items.firstIndex { $0.postID == visiblePostID }
+      ?? 0
+    _selectedIndex = State(initialValue: Double(initialIndex))
+  }
+
+  private var clampedIndex: Int {
+    min(max(Int(selectedIndex.rounded()), 0), items.count - 1)
+  }
+
+  private var selectedItem: PostDocumentNavigationItem {
+    items[clampedIndex]
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 20) {
+      HStack {
+        Text("楼层电梯")
+          .font(.headline)
+
+        Spacer()
+
+        Text(selectedItem.floor)
+          .font(.headline)
+          .monospacedDigit()
+
+        Button {
+          dismiss()
+        } label: {
+          Label("完成", systemImage: "xmark")
+            .labelStyle(.iconOnly)
+        }
+        .buttonStyle(.bordered)
+      }
+
+      Slider(
+        value: $selectedIndex,
+        in: 0...Double(items.count - 1),
+        step: 1,
+        label: {
+          Text("楼层")
+        },
+        minimumValueLabel: {
+          Text(items[0].floor)
+            .font(.caption)
+            .monospacedDigit()
+        },
+        maximumValueLabel: {
+          Text(items[items.count - 1].floor)
+            .font(.caption)
+            .monospacedDigit()
+        },
+        onEditingChanged: { isEditing in
+          if !isEditing {
+            selectCurrentItem()
+          }
+        }
+      )
+      .accessibilityValue(Text(selectedItem.floor))
+
+      HStack {
+        Button {
+          select(index: clampedIndex - 1)
+        } label: {
+          Label("上一层", systemImage: "chevron.up")
+            .labelStyle(.iconOnly)
+        }
+        .disabled(clampedIndex == 0)
+
+        Spacer()
+
+        Button {
+          onSelect(.top)
+        } label: {
+          Label("回到顶部", systemImage: "arrow.up.to.line")
+            .labelStyle(.iconOnly)
+        }
+
+        Button {
+          onSelect(.bottom)
+        } label: {
+          Label("跳到底部", systemImage: "arrow.down.to.line")
+            .labelStyle(.iconOnly)
+        }
+
+        Spacer()
+
+        Button {
+          select(index: clampedIndex + 1)
+        } label: {
+          Label("下一层", systemImage: "chevron.down")
+            .labelStyle(.iconOnly)
+        }
+        .disabled(clampedIndex == items.count - 1)
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.large)
+    }
+    .padding()
+    .presentationDetents([.medium])
+    .presentationDragIndicator(.visible)
+  }
+
+  private func select(index: Int) {
+    let index = min(max(index, 0), items.count - 1)
+    selectedIndex = Double(index)
+    onSelect(.post(items[index].postID))
+  }
+
+  private func selectCurrentItem() {
+    onSelect(.post(selectedItem.postID))
+  }
+}

--- a/App/Components/PostDocumentNavigator.swift
+++ b/App/Components/PostDocumentNavigator.swift
@@ -31,7 +31,8 @@ struct PostDocumentViewportState: Equatable, Sendable {
   )
 }
 
-struct PostDocumentFilterSortConfiguration {
+struct PostDocumentControlConfiguration {
+  let canReply: Bool
   let filterModes: [ReplyFilterMode]
   let filterMode: Binding<ReplyFilterMode>
   let sortOrder: Binding<ReplySortOrder>
@@ -40,8 +41,9 @@ struct PostDocumentFilterSortConfiguration {
 struct PostDocumentNavigatorOverlay: View {
   let items: [PostDocumentNavigationItem]
   let visiblePostID: Int?
-  let controls: PostDocumentFilterSortConfiguration
+  let controls: PostDocumentControlConfiguration
   let canScrollToTop: Bool
+  let onReply: () -> Void
   let onSelect: (PostDocumentScrollTarget) -> Void
 
   @State private var showsFloorNavigator = false
@@ -58,6 +60,13 @@ struct PostDocumentNavigatorOverlay: View {
 
   var body: some View {
     HStack(spacing: 8) {
+      Button(action: onReply) {
+        Label("回复", systemImage: "plus.bubble")
+          .labelStyle(.iconOnly)
+      }
+      .adaptiveButtonStyle(.bordered)
+      .disabled(!controls.canReply)
+
       PostDocumentFilterSortControls(configuration: controls)
 
       if items.count > 1 {
@@ -105,7 +114,7 @@ private struct PostDocumentFilterSortControls: View {
   @Binding var filterMode: ReplyFilterMode
   @Binding var sortOrder: ReplySortOrder
 
-  init(configuration: PostDocumentFilterSortConfiguration) {
+  init(configuration: PostDocumentControlConfiguration) {
     filterModes = configuration.filterModes
     _filterMode = configuration.filterMode
     _sortOrder = configuration.sortOrder

--- a/App/Components/PostDocumentRenderer.swift
+++ b/App/Components/PostDocumentRenderer.swift
@@ -5,6 +5,7 @@ struct PostWebDocument: Equatable, Sendable {
   let html: String
   let baseURL: URL
   let initialPostID: Int?
+  let navigationItems: [PostDocumentNavigationItem]
 }
 
 struct PostDocumentRenderInput: Hashable, Sendable {
@@ -551,6 +552,7 @@ actor PostDocumentRenderer {
         <script>
           (() => {
             const bridge = window.webkit?.messageHandlers?.postAction;
+            const viewportBridge = window.webkit?.messageHandlers?.postViewport;
             const post = (payload) => bridge?.postMessage(payload);
             const previewableImage = (target) => {
               const image = target.closest('.post-content img');
@@ -675,6 +677,53 @@ actor PostDocumentRenderer {
                 image.style.maxHeight = '';
               }
             });
+
+            const floorPosts = Array.from(document.querySelectorAll('main > .reply'));
+            let viewportFrame = null;
+            let lastViewportState = '';
+            const reportViewport = () => {
+              viewportFrame = null;
+              const anchorY = Math.min(window.innerHeight * 0.32, 180);
+              let visiblePostId = null;
+
+              for (const floorPost of floorPosts) {
+                const rect = floorPost.getBoundingClientRect();
+                const postId = Number(floorPost.id.slice(5));
+                if (rect.top <= anchorY) {
+                  visiblePostId = postId;
+                  continue;
+                }
+                if (visiblePostId === null && rect.top < window.innerHeight) {
+                  visiblePostId = postId;
+                }
+                break;
+              }
+
+              const canScrollToTop = window.scrollY > 44;
+              const state = `${canScrollToTop}:${visiblePostId ?? ''}`;
+              if (state === lastViewportState) {
+                return;
+              }
+              lastViewportState = state;
+              viewportBridge?.postMessage({
+                canScrollToTop,
+                postId: visiblePostId,
+              });
+            };
+            const scheduleViewportReport = () => {
+              if (viewportFrame === null) {
+                viewportFrame = window.requestAnimationFrame(reportViewport);
+              }
+            };
+
+            window.addEventListener('scroll', scheduleViewportReport, {passive: true});
+            window.addEventListener('resize', scheduleViewportReport, {passive: true});
+            document.querySelectorAll('img').forEach((image) => {
+              if (!image.complete) {
+                image.addEventListener('load', scheduleViewportReport, {once: true});
+              }
+            });
+            scheduleViewportReport();
           })();
         </script>
       </body>
@@ -686,7 +735,10 @@ actor PostDocumentRenderer {
       id: UUID(),
       html: html,
       baseURL: input.baseURL,
-      initialPostID: input.initialPostID
+      initialPostID: input.initialPostID,
+      navigationItems: input.replies.map {
+        PostDocumentNavigationItem(postID: $0.id, floor: $0.floor)
+      }
     )
   }
 

--- a/App/Components/PostDocumentRenderer.swift
+++ b/App/Components/PostDocumentRenderer.swift
@@ -679,6 +679,7 @@ actor PostDocumentRenderer {
             });
 
             const floorPosts = Array.from(document.querySelectorAll('main > .reply'));
+            let visibleFloorIndex = floorPosts.length > 0 ? 0 : -1;
             let viewportFrame = null;
             let lastViewportState = '';
             const reportViewport = () => {
@@ -686,17 +687,26 @@ actor PostDocumentRenderer {
               const anchorY = Math.min(window.innerHeight * 0.32, 180);
               let visiblePostId = null;
 
-              for (const floorPost of floorPosts) {
+              while (
+                visibleFloorIndex + 1 < floorPosts.length
+                && floorPosts[visibleFloorIndex + 1].getBoundingClientRect().top
+                  <= anchorY
+              ) {
+                visibleFloorIndex += 1;
+              }
+              while (
+                visibleFloorIndex > 0
+                && floorPosts[visibleFloorIndex].getBoundingClientRect().top > anchorY
+              ) {
+                visibleFloorIndex -= 1;
+              }
+
+              if (visibleFloorIndex >= 0) {
+                const floorPost = floorPosts[visibleFloorIndex];
                 const rect = floorPost.getBoundingClientRect();
-                const postId = Number(floorPost.id.slice(5));
-                if (rect.top <= anchorY) {
-                  visiblePostId = postId;
-                  continue;
+                if (rect.top <= anchorY || rect.top < window.innerHeight) {
+                  visiblePostId = Number(floorPost.id.slice(5));
                 }
-                if (visiblePostId === null && rect.top < window.innerHeight) {
-                  visiblePostId = postId;
-                }
-                break;
               }
 
               const canScrollToTop = window.scrollY > 44;

--- a/App/Components/PostDocumentWebView.swift
+++ b/App/Components/PostDocumentWebView.swift
@@ -425,7 +425,7 @@ struct PostDocumentWebView: UIViewRepresentable {
 
 struct PostDocumentSurface: View {
   let input: PostDocumentRenderInput
-  let controls: PostDocumentFilterSortConfiguration
+  let controls: PostDocumentControlConfiguration
   let onAction: (PostDocumentAction) -> Void
   let onOpenURL: (URL) -> Void
   let onRefresh: () async -> Void
@@ -452,6 +452,9 @@ struct PostDocumentSurface: View {
           visiblePostID: viewportState.visiblePostID,
           controls: controls,
           canScrollToTop: viewportState.canScrollToTop,
+          onReply: {
+            onAction(.newReply)
+          },
           onSelect: requestScroll
         )
         .id(document.id)

--- a/App/Components/PostDocumentWebView.swift
+++ b/App/Components/PostDocumentWebView.swift
@@ -251,7 +251,7 @@ struct PostDocumentWebView: UIViewRepresentable {
     }
 
     private func perform(_ request: PostDocumentScrollRequest, in webView: WKWebView) {
-      cancelPendingPostAlignment(in: webView)
+      cancelPendingDocumentAlignment(in: webView)
 
       switch request.target {
       case .top:
@@ -260,16 +260,7 @@ struct PostDocumentWebView: UIViewRepresentable {
           animated: request.animated
         )
       case .bottom:
-        let minimumOffset = -webView.scrollView.adjustedContentInset.top
-        let maximumOffset = max(
-          minimumOffset,
-          webView.scrollView.contentSize.height - webView.scrollView.bounds.height
-            + webView.scrollView.adjustedContentInset.bottom
-        )
-        webView.scrollView.setContentOffset(
-          CGPoint(x: 0, y: maximumOffset),
-          animated: request.animated
-        )
+        scrollToBottom(animated: request.animated, in: webView)
       case .post(let postID):
         scrollToPost(
           postID,
@@ -280,11 +271,78 @@ struct PostDocumentWebView: UIViewRepresentable {
       }
     }
 
-    private func cancelPendingPostAlignment(in webView: WKWebView) {
+    private func cancelPendingDocumentAlignment(in webView: WKWebView) {
       webView.evaluateJavaScript(
         """
         window.postDocumentScrollGeneration =
           (window.postDocumentScrollGeneration ?? 0) + 1;
+        window.postDocumentBottomObserver?.disconnect();
+        window.postDocumentBottomObserver = null;
+        """
+      )
+    }
+
+    private func scrollToBottom(animated: Bool, in webView: WKWebView) {
+      webView.evaluateJavaScript(
+        """
+        (() => {
+          window.postDocumentScrollGeneration =
+            (window.postDocumentScrollGeneration ?? 0) + 1;
+          window.postDocumentBottomObserver?.disconnect();
+
+          const generation = window.postDocumentScrollGeneration;
+          const scrollingElement =
+            document.scrollingElement ?? document.documentElement;
+          let userInteracted = false;
+          let lastDocumentHeight = scrollingElement.scrollHeight;
+          let observer = null;
+
+          const stop = () => {
+            userInteracted = true;
+            observer?.disconnect();
+            if (window.postDocumentBottomObserver === observer) {
+              window.postDocumentBottomObserver = null;
+            }
+          };
+          document.addEventListener('touchstart', stop, {once: true, passive: true});
+          document.addEventListener('pointerdown', stop, {once: true, passive: true});
+          document.addEventListener('wheel', stop, {once: true, passive: true});
+
+          const align = (behavior) => {
+            if (
+              !userInteracted
+              && window.postDocumentScrollGeneration === generation
+            ) {
+              window.scrollTo({
+                top: scrollingElement.scrollHeight,
+                behavior,
+              });
+            }
+          };
+
+          align('\(animated ? "smooth" : "auto")');
+          observer = new ResizeObserver(() => {
+            const documentHeight = scrollingElement.scrollHeight;
+            if (documentHeight === lastDocumentHeight) {
+              return;
+            }
+            lastDocumentHeight = documentHeight;
+            window.requestAnimationFrame(() => align('auto'));
+          });
+          observer.observe(document.documentElement);
+          if (document.body) {
+            observer.observe(document.body);
+          }
+          window.postDocumentBottomObserver = observer;
+
+          window.setTimeout(() => {
+            align('auto');
+            observer.disconnect();
+            if (window.postDocumentBottomObserver === observer) {
+              window.postDocumentBottomObserver = null;
+            }
+          }, 3000);
+        })();
         """
       )
     }
@@ -303,6 +361,8 @@ struct PostDocumentWebView: UIViewRepresentable {
             return;
           }
 
+          window.postDocumentBottomObserver?.disconnect();
+          window.postDocumentBottomObserver = null;
           window.postDocumentScrollGeneration =
             (window.postDocumentScrollGeneration ?? 0) + 1;
           const generation = window.postDocumentScrollGeneration;
@@ -446,6 +506,7 @@ struct PostDocumentSurface: View {
           onRefresh: onRefresh,
           onViewportChange: updateViewportState
         )
+        .ignoresSafeArea(.container, edges: .vertical)
 
         PostDocumentNavigatorOverlay(
           items: document.navigationItems,
@@ -464,8 +525,10 @@ struct PostDocumentSurface: View {
         ProgressView()
       }
     }
-    .background(Color(uiColor: .systemBackground))
-    .ignoresSafeArea(.container, edges: .vertical)
+    .background {
+      Color(uiColor: .systemBackground)
+        .ignoresSafeArea(.container, edges: .vertical)
+    }
     .task(id: input) {
       do {
         let document = try await PostDocumentRenderer.shared.render(input)

--- a/App/Components/PostDocumentWebView.swift
+++ b/App/Components/PostDocumentWebView.swift
@@ -14,22 +14,32 @@ enum PostDocumentAction: Equatable {
 
 struct PostDocumentWebView: UIViewRepresentable {
   let document: PostWebDocument
+  let scrollRequest: PostDocumentScrollRequest?
   let onAction: (PostDocumentAction) -> Void
   let onOpenURL: (URL) -> Void
   let onRefresh: () async -> Void
+  let onViewportChange: (PostDocumentViewportState) -> Void
 
   func makeCoordinator() -> Coordinator {
     Coordinator(
       onAction: onAction,
       onOpenURL: onOpenURL,
-      onRefresh: onRefresh
+      onRefresh: onRefresh,
+      onViewportChange: onViewportChange
     )
   }
 
   func makeUIView(context: Context) -> WKWebView {
     let configuration = WKWebViewConfiguration()
     configuration.defaultWebpagePreferences.allowsContentJavaScript = true
-    configuration.userContentController.add(context.coordinator, name: Coordinator.messageName)
+    configuration.userContentController.add(
+      context.coordinator,
+      name: Coordinator.actionMessageName
+    )
+    configuration.userContentController.add(
+      context.coordinator,
+      name: Coordinator.viewportMessageName
+    )
     configuration.setURLSchemeHandler(
       PostStickerSchemeHandler(),
       forURLScheme: PostDocumentRenderer.stickerURLScheme
@@ -54,6 +64,7 @@ struct PostDocumentWebView: UIViewRepresentable {
 
     context.coordinator.webView = webView
     context.coordinator.update(document: document)
+    context.coordinator.handle(scrollRequest)
     return webView
   }
 
@@ -61,37 +72,48 @@ struct PostDocumentWebView: UIViewRepresentable {
     context.coordinator.onAction = onAction
     context.coordinator.onOpenURL = onOpenURL
     context.coordinator.onRefresh = onRefresh
+    context.coordinator.onViewportChange = onViewportChange
     context.coordinator.update(document: document)
+    context.coordinator.handle(scrollRequest)
   }
 
   static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
     webView.configuration.userContentController.removeScriptMessageHandler(
-      forName: Coordinator.messageName
+      forName: Coordinator.actionMessageName
+    )
+    webView.configuration.userContentController.removeScriptMessageHandler(
+      forName: Coordinator.viewportMessageName
     )
     webView.navigationDelegate = nil
   }
 
   @MainActor
   final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
-    static let messageName = "postAction"
+    static let actionMessageName = "postAction"
+    static let viewportMessageName = "postViewport"
 
     weak var webView: WKWebView?
     var onAction: (PostDocumentAction) -> Void
     var onOpenURL: (URL) -> Void
     var onRefresh: () async -> Void
+    var onViewportChange: (PostDocumentViewportState) -> Void
 
     private var currentDocument: PostWebDocument?
     private var pendingScrollOffset: CGPoint?
     private var pendingInitialPostID: Int?
+    private var pendingScrollRequest: PostDocumentScrollRequest?
+    private var handledScrollRequestID: UUID?
 
     init(
       onAction: @escaping (PostDocumentAction) -> Void,
       onOpenURL: @escaping (URL) -> Void,
-      onRefresh: @escaping () async -> Void
+      onRefresh: @escaping () async -> Void,
+      onViewportChange: @escaping (PostDocumentViewportState) -> Void
     ) {
       self.onAction = onAction
       self.onOpenURL = onOpenURL
       self.onRefresh = onRefresh
+      self.onViewportChange = onViewportChange
     }
 
     func update(document: PostWebDocument) {
@@ -110,6 +132,19 @@ struct PostDocumentWebView: UIViewRepresentable {
       webView?.loadHTMLString(document.html, baseURL: document.baseURL)
     }
 
+    func handle(_ request: PostDocumentScrollRequest?) {
+      guard let request, handledScrollRequestID != request.id else {
+        return
+      }
+      handledScrollRequestID = request.id
+
+      guard let webView, !webView.isLoading else {
+        pendingScrollRequest = request
+        return
+      }
+      perform(request, in: webView)
+    }
+
     @objc func refresh() {
       Task {
         await onRefresh()
@@ -121,15 +156,31 @@ struct PostDocumentWebView: UIViewRepresentable {
       _ userContentController: WKUserContentController,
       didReceive message: WKScriptMessage
     ) {
-      guard message.name == Self.messageName,
-        let payload = message.body as? [String: Any],
-        let actionName = payload["action"] as? String,
-        let action = makeAction(name: actionName, payload: payload)
-      else {
+      guard let payload = message.body as? [String: Any] else {
         return
       }
 
-      onAction(action)
+      switch message.name {
+      case Self.actionMessageName:
+        guard let actionName = payload["action"] as? String,
+          let action = makeAction(name: actionName, payload: payload)
+        else {
+          return
+        }
+        onAction(action)
+      case Self.viewportMessageName:
+        guard let canScrollToTop = boolean(payload["canScrollToTop"]) else {
+          return
+        }
+        onViewportChange(
+          PostDocumentViewportState(
+            canScrollToTop: canScrollToTop,
+            visiblePostID: integer(payload["postId"])
+          )
+        )
+      default:
+        return
+      }
     }
 
     func webView(
@@ -149,6 +200,14 @@ struct PostDocumentWebView: UIViewRepresentable {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation?) {
+      if let pendingScrollRequest {
+        self.pendingScrollRequest = nil
+        pendingScrollOffset = nil
+        pendingInitialPostID = nil
+        perform(pendingScrollRequest, in: webView)
+        return
+      }
+
       if let pendingScrollOffset {
         self.pendingScrollOffset = nil
         let minimumOffset = -webView.scrollView.adjustedContentInset.top
@@ -171,31 +230,11 @@ struct PostDocumentWebView: UIViewRepresentable {
         return
       }
       self.pendingInitialPostID = nil
-      webView.evaluateJavaScript(
-        """
-        (() => {
-          const target = document.getElementById('post_\(pendingInitialPostID)');
-          if (!target) {
-            return;
-          }
-
-          let userInteracted = false;
-          const cancel = () => {
-            userInteracted = true;
-          };
-          document.addEventListener('touchstart', cancel, {once: true, passive: true});
-          document.addEventListener('pointerdown', cancel, {once: true, passive: true});
-
-          const align = () => {
-            if (!userInteracted) {
-              target.scrollIntoView({block: 'start'});
-            }
-          };
-          align();
-          window.setTimeout(align, 250);
-          window.setTimeout(align, 750);
-        })();
-        """
+      scrollToPost(
+        pendingInitialPostID,
+        animated: false,
+        stabilizesPosition: true,
+        in: webView
       )
     }
 
@@ -209,6 +248,90 @@ struct PostDocumentWebView: UIViewRepresentable {
 
     private func captureScrollOffsetIfNeeded(from webView: WKWebView) {
       pendingScrollOffset = pendingScrollOffset ?? webView.scrollView.contentOffset
+    }
+
+    private func perform(_ request: PostDocumentScrollRequest, in webView: WKWebView) {
+      cancelPendingPostAlignment(in: webView)
+
+      switch request.target {
+      case .top:
+        webView.scrollView.setContentOffset(
+          CGPoint(x: 0, y: -webView.scrollView.adjustedContentInset.top),
+          animated: request.animated
+        )
+      case .bottom:
+        let minimumOffset = -webView.scrollView.adjustedContentInset.top
+        let maximumOffset = max(
+          minimumOffset,
+          webView.scrollView.contentSize.height - webView.scrollView.bounds.height
+            + webView.scrollView.adjustedContentInset.bottom
+        )
+        webView.scrollView.setContentOffset(
+          CGPoint(x: 0, y: maximumOffset),
+          animated: request.animated
+        )
+      case .post(let postID):
+        scrollToPost(
+          postID,
+          animated: request.animated,
+          stabilizesPosition: false,
+          in: webView
+        )
+      }
+    }
+
+    private func cancelPendingPostAlignment(in webView: WKWebView) {
+      webView.evaluateJavaScript(
+        """
+        window.postDocumentScrollGeneration =
+          (window.postDocumentScrollGeneration ?? 0) + 1;
+        """
+      )
+    }
+
+    private func scrollToPost(
+      _ postID: Int,
+      animated: Bool,
+      stabilizesPosition: Bool,
+      in webView: WKWebView
+    ) {
+      webView.evaluateJavaScript(
+        """
+        (() => {
+          const target = document.getElementById('post_\(postID)');
+          if (!target) {
+            return;
+          }
+
+          window.postDocumentScrollGeneration =
+            (window.postDocumentScrollGeneration ?? 0) + 1;
+          const generation = window.postDocumentScrollGeneration;
+          const stabilizesPosition = \(stabilizesPosition ? "true" : "false");
+          let userInteracted = false;
+          const cancel = () => {
+            userInteracted = true;
+          };
+          if (stabilizesPosition) {
+            document.addEventListener('touchstart', cancel, {once: true, passive: true});
+            document.addEventListener('pointerdown', cancel, {once: true, passive: true});
+          }
+
+          const align = (behavior) => {
+            if (
+              !userInteracted
+              && window.postDocumentScrollGeneration === generation
+            ) {
+              target.scrollIntoView({block: 'start', behavior});
+            }
+          };
+          align('\(animated ? "smooth" : "auto")');
+          if (stabilizesPosition) {
+            window.setTimeout(() => align('auto'), 250);
+            window.setTimeout(() => align('auto'), 750);
+          }
+        })();
+        """
+      )
     }
 
     private func makeAction(
@@ -287,26 +410,53 @@ struct PostDocumentWebView: UIViewRepresentable {
       return nil
     }
 
+    private func boolean(_ value: Any?) -> Bool? {
+      if let value = value as? Bool {
+        return value
+      }
+      if let number = value as? NSNumber {
+        return number.boolValue
+      }
+      return nil
+    }
+
   }
 }
 
 struct PostDocumentSurface: View {
   let input: PostDocumentRenderInput
+  let controls: PostDocumentFilterSortConfiguration
   let onAction: (PostDocumentAction) -> Void
   let onOpenURL: (URL) -> Void
   let onRefresh: () async -> Void
 
   @State private var document: PostWebDocument?
+  @State private var scrollRequest: PostDocumentScrollRequest?
+  @State private var viewportState = PostDocumentViewportState.top
+  @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
 
   var body: some View {
-    ZStack {
+    ZStack(alignment: .bottomTrailing) {
       if let document {
         PostDocumentWebView(
           document: document,
+          scrollRequest: scrollRequest,
           onAction: onAction,
           onOpenURL: onOpenURL,
-          onRefresh: onRefresh
+          onRefresh: onRefresh,
+          onViewportChange: updateViewportState
         )
+
+        PostDocumentNavigatorOverlay(
+          items: document.navigationItems,
+          visiblePostID: viewportState.visiblePostID,
+          controls: controls,
+          canScrollToTop: viewportState.canScrollToTop,
+          onSelect: requestScroll
+        )
+        .id(document.id)
+        .padding(.trailing, 12)
+        .safeAreaPadding(.bottom, 12)
       } else {
         ProgressView()
       }
@@ -324,6 +474,17 @@ struct PostDocumentSurface: View {
         assertionFailure("Unexpected post document rendering error: \(error)")
       }
     }
+  }
+
+  private func requestScroll(_ target: PostDocumentScrollTarget) {
+    scrollRequest = PostDocumentScrollRequest(
+      target: target,
+      animated: !accessibilityReduceMotion
+    )
+  }
+
+  private func updateViewportState(_ state: PostDocumentViewportState) {
+    viewportState = state
   }
 }
 

--- a/App/Helpers/View+AdaptiveButtonStyle.swift
+++ b/App/Helpers/View+AdaptiveButtonStyle.swift
@@ -35,4 +35,13 @@ extension View {
       }
     }
   }
+
+  @ViewBuilder
+  func adaptiveFlexibleButtonSizing() -> some View {
+    if #available(iOS 26.0, *) {
+      self.buttonSizing(.flexible)
+    } else {
+      self
+    }
+  }
 }

--- a/App/Views/Comment/CommentListView.swift
+++ b/App/Views/Comment/CommentListView.swift
@@ -207,7 +207,8 @@ struct CommentListView: View {
       let presentation = commentPresentation()
       PostDocumentSurface(
         input: renderInput(presentation),
-        controls: PostDocumentFilterSortConfiguration(
+        controls: PostDocumentControlConfiguration(
+          canReply: canReply,
           filterModes: availableFilterModes,
           filterMode: $filterMode,
           sortOrder: $sortSelection[fallback: replySortOrder]

--- a/App/Views/Comment/CommentListView.swift
+++ b/App/Views/Comment/CommentListView.swift
@@ -207,6 +207,11 @@ struct CommentListView: View {
       let presentation = commentPresentation()
       PostDocumentSurface(
         input: renderInput(presentation),
+        controls: PostDocumentFilterSortConfiguration(
+          filterModes: availableFilterModes,
+          filterMode: $filterMode,
+          sortOrder: $sortSelection[fallback: replySortOrder]
+        ),
         onAction: handleDocumentAction,
         onOpenURL: { url in
           openURL(url)

--- a/App/Views/Topic/TopicDetailView.swift
+++ b/App/Views/Topic/TopicDetailView.swift
@@ -326,6 +326,11 @@ struct TopicDetailView: View {
       let presentation = replyPresentation(data)
       PostDocumentSurface(
         input: renderInput(data, presentation: presentation),
+        controls: PostDocumentFilterSortConfiguration(
+          filterModes: ReplyFilterMode.allCases,
+          filterMode: $filterMode,
+          sortOrder: $sortSelection[fallback: replySortOrder]
+        ),
         onAction: handleDocumentAction,
         onOpenURL: { url in
           openURL(url)

--- a/App/Views/Topic/TopicDetailView.swift
+++ b/App/Views/Topic/TopicDetailView.swift
@@ -275,6 +275,10 @@ struct TopicDetailView: View {
     sortSelection[fallback: replySortOrder]
   }
 
+  private var canReply: Bool {
+    isAuthenticated && (data?.state.allowReply ?? true)
+  }
+
   var body: some View {
     content
       .navigationTitle(title)
@@ -326,7 +330,8 @@ struct TopicDetailView: View {
       let presentation = replyPresentation(data)
       PostDocumentSurface(
         input: renderInput(data, presentation: presentation),
-        controls: PostDocumentFilterSortConfiguration(
+        controls: PostDocumentControlConfiguration(
+          canReply: canReply,
           filterModes: ReplyFilterMode.allCases,
           filterMode: $filterMode,
           sortOrder: $sortSelection[fallback: replySortOrder]
@@ -377,7 +382,7 @@ struct TopicDetailView: View {
         } label: {
           Label("回复", systemImage: "plus.bubble")
         }
-        .disabled(!isAuthenticated || !(data?.state.allowReply ?? true))
+        .disabled(!canReply)
 
         Button {
           sheet = .index


### PR DESCRIPTION
## Summary

Add shared floating navigation controls to topic details and comment lists, including reply, filter, sort, floor selection, and scroll-to-top actions.

The post document bridge now reports the visible floor and scroll position, while explicit navigation requests are routed back to the WebView without repeated alignment work. Post action menus and reaction panels also adopt the existing adaptive Glass styling.

## UX impact

Reply, filter, and sort remain available in the toolbar while also staying accessible beside the floor elevator. The reply action shares each screen's existing availability state, while the control row keeps a stable width as floor numbers change, disables scroll-to-top near the top, and uses native Glass styling where available with older-system fallbacks.

## Validation

- `make build`
- `swift-format lint` on touched Swift files
- `git diff --check`
