### PR TITLE
fix: keep tab refreshes running after switching

### DIFF
--- a/App/Views/Discover/CalendarSlimView.swift
+++ b/App/Views/Discover/CalendarSlimView.swift
@@ -25,6 +25,7 @@ struct CalendarSlimView: View {
 
   @State private var currentDate = Calendar.current.startOfDay(for: Date())
   @State private var refreshed: Bool = false
+  @State private var loading: Bool = false
   @State private var calendars: [CalendarEntryDTO] = []
   @State private var collectionTypes: [Int: CollectionType] = [:]
 
@@ -127,13 +128,20 @@ struct CalendarSlimView: View {
     }
   }
 
+  private func loadIfNeeded() async {
+    guard !refreshed, !loading else { return }
+    loading = true
+    defer {
+      loading = false
+    }
+    await loadCachedCalendar()
+    await refreshCalendar()
+  }
+
   var body: some View {
     VStack {
       if calendars.isEmpty {
-        ProgressView().task {
-          await loadCachedCalendar()
-          await refreshCalendar()
-        }
+        ProgressView()
       } else {
         VStack(alignment: .leading, spacing: 8) {
           HStack(alignment: .bottom) {
@@ -176,6 +184,9 @@ struct CalendarSlimView: View {
     .padding(.horizontal, 8)
     .onAppear {
       updateCurrentDate()
+      Task {
+        await loadIfNeeded()
+      }
     }
     .onChange(of: scenePhase) {
       if scenePhase == .active {

--- a/App/Views/Discover/CalendarSlimView.swift
+++ b/App/Views/Discover/CalendarSlimView.swift
@@ -2,6 +2,7 @@ import OSLog
 import SwiftUI
 
 struct CalendarSlimView: View {
+  let reloadToken: Int
 
   private struct CalendarDay: Identifiable {
     let weekday: WeekDay
@@ -24,8 +25,6 @@ struct CalendarSlimView: View {
   @Environment(\.scenePhase) private var scenePhase
 
   @State private var currentDate = Calendar.current.startOfDay(for: Date())
-  @State private var refreshed: Bool = false
-  @State private var loading: Bool = false
   @State private var calendars: [CalendarEntryDTO] = []
   @State private var collectionTypes: [Int: CollectionType] = [:]
 
@@ -117,27 +116,6 @@ struct CalendarSlimView: View {
     }
   }
 
-  func refreshCalendar() async {
-    if refreshed { return }
-    refreshed = true
-    do {
-      try await DiscoveryRepository.loadCalendar()
-      await loadCachedCalendar()
-    } catch {
-      Notifier.shared.alert(error: error)
-    }
-  }
-
-  private func loadIfNeeded() async {
-    guard !refreshed, !loading else { return }
-    loading = true
-    defer {
-      loading = false
-    }
-    await loadCachedCalendar()
-    await refreshCalendar()
-  }
-
   var body: some View {
     VStack {
       if calendars.isEmpty {
@@ -184,9 +162,9 @@ struct CalendarSlimView: View {
     .padding(.horizontal, 8)
     .onAppear {
       updateCurrentDate()
-      Task {
-        await loadIfNeeded()
-      }
+    }
+    .task(id: reloadToken) {
+      await loadCachedCalendar()
     }
     .onChange(of: scenePhase) {
       if scenePhase == .active {

--- a/App/Views/Discover/ChiiDiscoverView.swift
+++ b/App/Views/Discover/ChiiDiscoverView.swift
@@ -6,13 +6,46 @@ struct ChiiDiscoverView: View {
   @State private var searching: Bool = false
   @State private var remote: Bool = false
   @State private var showsSearch = false
+  @State private var didInitialRefresh = false
+  @State private var refreshing = false
+  @State private var calendarReloadToken = 0
+  @State private var trendingReloadToken = 0
 
-  func refresh() async {
+  private func refreshCalendar() async {
     do {
       try await DiscoveryRepository.loadCalendar()
-      try await DiscoveryRepository.loadTrendingSubjects()
+      calendarReloadToken += 1
     } catch {
       Notifier.shared.alert(error: error)
+    }
+  }
+
+  private func refreshTrendingSubjects() async {
+    do {
+      try await DiscoveryRepository.loadTrendingSubjects()
+      trendingReloadToken += 1
+    } catch {
+      Notifier.shared.alert(error: error)
+    }
+  }
+
+  private func refresh() async {
+    guard !refreshing else { return }
+    refreshing = true
+    defer {
+      refreshing = false
+    }
+
+    async let calendar: Void = refreshCalendar()
+    async let trending: Void = refreshTrendingSubjects()
+    _ = await (calendar, trending)
+  }
+
+  private func refreshInitiallyIfNeeded() {
+    guard !didInitialRefresh else { return }
+    didInitialRefresh = true
+    Task {
+      await refresh()
     }
   }
 
@@ -22,8 +55,11 @@ struct ChiiDiscoverView: View {
         if !showsSearch {
           ScrollView {
             VStack {
-              CalendarSlimView()
-              TrendingSubjectView(width: geometry.size.width)
+              CalendarSlimView(reloadToken: calendarReloadToken)
+              TrendingSubjectView(
+                width: geometry.size.width,
+                reloadToken: trendingReloadToken
+              )
             }
           }
         } else {
@@ -44,6 +80,7 @@ struct ChiiDiscoverView: View {
     .searchInputTraits()
     .onAppear {
       showsSearch = !query.isEmpty
+      refreshInitiallyIfNeeded()
     }
     .onChange(of: query) { _, newValue in
       let nextShowsSearch = !newValue.isEmpty

--- a/App/Views/Discover/TrendingSubjectView.swift
+++ b/App/Views/Discover/TrendingSubjectView.swift
@@ -72,11 +72,14 @@ struct TrendingSubjectView: View {
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   @State private var loaded: Bool = false
+  @State private var loading: Bool = false
   @State private var reloader: Bool = false
 
   func load() async {
-    if loaded {
-      return
+    guard !loaded, !loading else { return }
+    loading = true
+    defer {
+      loading = false
     }
     do {
       try await DiscoveryRepository.loadTrendingSubjects()
@@ -97,7 +100,11 @@ struct TrendingSubjectView: View {
       }
     }
     .padding(.horizontal, 8)
-    .task(load)
+    .onAppear {
+      Task {
+        await load()
+      }
+    }
   }
 }
 

--- a/App/Views/Discover/TrendingSubjectView.swift
+++ b/App/Views/Discover/TrendingSubjectView.swift
@@ -66,52 +66,31 @@ private struct TrendingSubjectCollapseState: Equatable, RawRepresentable {
 
 struct TrendingSubjectView: View {
   let width: CGFloat
+  let reloadToken: Int
 
   @AppStorage("trendingSubjectCollapseState")
   private var collapseState: TrendingSubjectCollapseState = TrendingSubjectCollapseState()
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
-  @State private var loaded: Bool = false
-  @State private var loading: Bool = false
-  @State private var reloader: Bool = false
-
-  func load() async {
-    guard !loaded, !loading else { return }
-    loading = true
-    defer {
-      loading = false
-    }
-    do {
-      try await DiscoveryRepository.loadTrendingSubjects()
-      withAnimation(.default) {
-        loaded = true
-        reloader.toggle()
-      }
-    } catch {
-      Notifier.shared.alert(error: error)
-    }
-  }
-
   var body: some View {
     VStack(spacing: 24) {
       ForEach(SubjectType.allTypes) { type in
         TrendingSubjectTypeView(
-          type: type, width: width - 16, reloader: reloader, collapseState: $collapseState)
+          type: type,
+          width: width - 16,
+          reloadToken: reloadToken,
+          collapseState: $collapseState
+        )
       }
     }
     .padding(.horizontal, 8)
-    .onAppear {
-      Task {
-        await load()
-      }
-    }
   }
 }
 
 private struct TrendingSubjectTypeView: View {
   let type: SubjectType
   let width: CGFloat
-  let reloader: Bool
+  let reloadToken: Int
   @Binding var collapseState: TrendingSubjectCollapseState
 
   @AppStorage("subjectImageQuality") var subjectImageQuality: ImageQuality = .high
@@ -235,7 +214,7 @@ private struct TrendingSubjectTypeView: View {
         .scrollTargetBehavior(.viewAligned)
       }
     }
-    .task(id: "\(type.rawValue)-\(reloader)") {
+    .task(id: "\(type.rawValue)-\(reloadToken)") {
       await loadCached()
     }
     .onReceive(

--- a/App/Views/Progress/ChiiProgressView.swift
+++ b/App/Views/Progress/ChiiProgressView.swift
@@ -312,6 +312,21 @@ struct ChiiProgressView: View {
     await loadCounts()
   }
 
+  private func loadInitialProgressIfNeeded() {
+    guard !didInitialLoad else { return }
+    didInitialLoad = true
+    withAnimation(.default) {
+      refreshing = true
+    }
+    Task {
+      await loadLocalProgress()
+      withAnimation(.default) {
+        refreshing = false
+      }
+      await refresh(showProgress: false)
+    }
+  }
+
   func refresh(force: Bool = false, showProgress: Bool = true) async {
     let now = Date()
     if force {
@@ -514,18 +529,6 @@ struct ChiiProgressView: View {
       UIImpactFeedbackGenerator(style: .medium).impactOccurred()
       await refresh(showProgress: false)
     }
-    .task {
-      guard !didInitialLoad else { return }
-      didInitialLoad = true
-      withAnimation(.default) {
-        refreshing = true
-      }
-      await loadLocalProgress()
-      withAnimation(.default) {
-        refreshing = false
-      }
-      await refresh(showProgress: false)
-    }
     .searchable(
       text: $search,
       placement: .navigationBarDrawer(displayMode: .always),
@@ -544,6 +547,7 @@ struct ChiiProgressView: View {
       perform: handleProgressSubjectInvalidation
     )
     .onAppear {
+      loadInitialProgressIfNeeded()
       Task {
         await reloadPendingProgressSubjects()
       }

--- a/App/Views/Timeline/ChiiTimelineView.swift
+++ b/App/Views/Timeline/ChiiTimelineView.swift
@@ -8,8 +8,14 @@ struct ChiiTimelineView: View {
 
   @State private var logoutConfirm: Bool = false
   @State private var noticeUnreadCount: Int = 0
+  @State private var checkingNotice: Bool = false
 
   func checkNotice() async {
+    guard !checkingNotice else { return }
+    checkingNotice = true
+    defer {
+      checkingNotice = false
+    }
     if let cachedUnreadCount = await NoticeRepository.loadCachedUnreadCount() {
       noticeUnreadCount = cachedUnreadCount
     }
@@ -98,7 +104,11 @@ struct ChiiTimelineView: View {
           }
         }
       }
-      .task(checkNotice)
+      .onAppear {
+        Task {
+          await checkNotice()
+        }
+      }
       .onReceive(
         NotificationCenter.default.publisher(
           for: NoticeRepository.unreadCountDidChangeNotification

--- a/App/Views/Timeline/TimelineListView.swift
+++ b/App/Views/Timeline/TimelineListView.swift
@@ -82,6 +82,19 @@ struct TimelineListView: View {
     }
   }
 
+  private func loadInitialPageIfNeeded() {
+    guard items.isEmpty, !loading else { return }
+    withAnimation(.default) {
+      loading = true
+    }
+    Task {
+      await reload()
+      withAnimation(.default) {
+        loading = false
+      }
+    }
+  }
+
   var body: some View {
     let rows = items.timelineListRows(lastID: lastID)
 
@@ -152,18 +165,7 @@ struct TimelineListView: View {
         }
       }.padding(.horizontal, 8)
     }
-    .task {
-      if items.count > 0 {
-        return
-      }
-      withAnimation(.default) {
-        loading = true
-      }
-      await reload()
-      withAnimation(.default) {
-        loading = false
-      }
-    }
+    .onAppear(perform: loadInitialPageIfNeeded)
     .refreshable {
       await reload()
     }


### PR DESCRIPTION
## What changed

Keep initial refreshes for the progress, timeline, and discover tabs running after the user switches to another tab. The initial loads now start guarded tasks from `onAppear`, while pagination and cache projection tasks remain tied to their visible views.

## UX impact

Opening the app on a data-loading tab and switching away no longer interrupts its refresh. Rapid tab switching also avoids starting duplicate requests.

## Validation

- `make build`
