### PR TITLE
feat: refine comment entry actions

### DIFF
--- a/App/Components/CommentEditorSheets.swift
+++ b/App/Components/CommentEditorSheets.swift
@@ -19,7 +19,7 @@ struct CreateCommentBoxSheet: View {
     } else if let comment {
       return "回复 \(comment.user.nickname)"
     } else {
-      return "回复 \(type.title)"
+      return type.newCommentTitle
     }
   }
 

--- a/App/Components/CommentListNavigationLink.swift
+++ b/App/Components/CommentListNavigationLink.swift
@@ -33,40 +33,18 @@ struct CommentListNavigationLink: View {
 
   var body: some View {
     NavigationLink(value: NavDestination.commentList(route)) {
-      HStack(spacing: 10) {
+      HStack(spacing: 4) {
         Image(systemName: "bubble.left.and.bubble.right")
-          .font(.body)
-          .foregroundStyle(Color.accentColor)
-          .frame(width: 20)
-
-        Text(title)
-          .font(.subheadline.weight(.semibold))
-
-        Spacer(minLength: 6)
+          .accessibilityLabel(Text(title))
 
         if let count {
           Text("\(count)")
-            .font(.footnote)
-            .foregroundStyle(.secondary)
             .monospacedDigit()
         }
-
-        Image(systemName: "chevron.forward")
-          .font(.footnote.weight(.semibold))
-          .foregroundStyle(.tertiary)
       }
-      .padding(.horizontal, 12)
-      .padding(.vertical, 9)
-      .contentShape(Rectangle())
-      .background(
-        Color(uiColor: .secondarySystemBackground),
-        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
-      )
-      .overlay {
-        RoundedRectangle(cornerRadius: 10, style: .continuous)
-          .stroke(Color(uiColor: .separator).opacity(0.22), lineWidth: 0.5)
-      }
+      .font(.footnote)
+      .lineLimit(1)
     }
-    .buttonStyle(.plain)
+    .buttonStyle(.navigation)
   }
 }

--- a/App/Models/CommentParentType.swift
+++ b/App/Models/CommentParentType.swift
@@ -49,6 +49,17 @@ enum CommentParentType: Hashable, Sendable {
     }
   }
 
+  var newCommentTitle: String {
+    switch self {
+    case .index:
+      return "添加留言"
+    case .timeline:
+      return "添加回复"
+    default:
+      return "添加吐槽"
+    }
+  }
+
   var parentId: Int {
     switch self {
     case .blog(let id),

--- a/App/Views/Blog/BlogView.swift
+++ b/App/Views/Blog/BlogView.swift
@@ -58,6 +58,12 @@ struct BlogView: View {
                   .font(.caption)
                   .foregroundColor(.secondary)
                 Spacer()
+                if !isolationMode {
+                  CommentListNavigationLink(
+                    route: CommentListRoute(parent: .blog(blogId)),
+                    count: blog.replies
+                  )
+                }
                 Button {
                   showSubjects = true
                 } label: {
@@ -67,14 +73,6 @@ struct BlogView: View {
                 }.disabled(subjects.isEmpty)
               }
               Divider()
-
-              if !isolationMode {
-                CommentListNavigationLink(
-                  route: CommentListRoute(parent: .blog(blogId)),
-                  count: blog.replies
-                )
-                .padding(.top, 8)
-              }
 
               BBCodeView(blog.content)
                 .textSelection(.enabled)

--- a/App/Views/Character/CharacterView.swift
+++ b/App/Views/Character/CharacterView.swift
@@ -248,19 +248,21 @@ struct CharacterDetailView: View {
         .buttonStyle(.navigation)
         .padding(.vertical, 4)
 
-        Label("\(character.collects)人收藏", systemImage: "heart")
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
+        HStack {
+          Label("\(character.collects)人收藏", systemImage: "heart")
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+          Spacer(minLength: 8)
+          if !isolationMode {
+            CommentListNavigationLink(
+              route: CommentListRoute(parent: .character(character.id)),
+              count: character.comment
+            )
+          }
+        }
+        .font(.footnote)
       }.padding(.leading, 2)
     }.frame(height: 120)
-
-    if !isolationMode {
-      CommentListNavigationLink(
-        route: CommentListRoute(parent: .character(character.id)),
-        count: character.comment
-      )
-    }
 
     /// summary
     BBCodeView(character.summary, textSize: 14)

--- a/App/Views/Comment/CommentListView.swift
+++ b/App/Views/Comment/CommentListView.swift
@@ -243,7 +243,7 @@ struct CommentListView: View {
       Button {
         sheet = .newReply
       } label: {
-        Label("回复", systemImage: "plus.bubble")
+        Label(route.parent.newCommentTitle, systemImage: "plus.bubble")
       }
       .disabled(!canReply)
 

--- a/App/Views/Episode/EpisodeInfoView.swift
+++ b/App/Views/Episode/EpisodeInfoView.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 struct EpisodeInfoView: View {
   @AppStorage("isAuthenticated") var isAuthenticated: Bool = false
+  @AppStorage("isolationMode") var isolationMode: Bool = false
   @AppStorage("titlePreference") var titlePreference: TitlePreference = .original
 
   let episode: EpisodeDTO
+  var showsCommentLink: Bool = false
 
   func field(name: String, value: String) -> AttributedString {
     var text = AttributedString(name + ": ")
@@ -27,6 +29,12 @@ struct EpisodeInfoView: View {
             .fixedSize()
         }
         Spacer()
+        if showsCommentLink && !isolationMode {
+          CommentListNavigationLink(
+            route: CommentListRoute(parent: .episode(episode.id)),
+            count: episode.comment
+          )
+        }
       }
       Divider()
       if !episode.name.isEmpty {

--- a/App/Views/Episode/EpisodeView.swift
+++ b/App/Views/Episode/EpisodeView.swift
@@ -56,14 +56,7 @@ struct EpisodeView: View {
             SubjectTinyView(subject: subject)
               .padding(.vertical, 8)
           }
-          EpisodeInfoView(episode: episode)
-          if !isolationMode {
-            CommentListNavigationLink(
-              route: CommentListRoute(parent: .episode(episodeId)),
-              count: episode.comment
-            )
-            .padding(.top, 8)
-          }
+          EpisodeInfoView(episode: episode, showsCommentLink: true)
         }
         Divider()
         if let desc = episode?.desc, !desc.isEmpty {

--- a/App/Views/Index/IndexView.swift
+++ b/App/Views/Index/IndexView.swift
@@ -118,21 +118,23 @@ struct IndexView: View {
                   Text("创建: \(index.createdAt.datetimeDisplay)")
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
-                  Text("更新: \(index.updatedAt.datetimeDisplay)")
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
+                  HStack {
+                    Text("更新: \(index.updatedAt.datetimeDisplay)")
+                      .foregroundStyle(.secondary)
+                      .monospacedDigit()
+                    Spacer(minLength: 8)
+                    if !isolationMode {
+                      CommentListNavigationLink(
+                        route: CommentListRoute(parent: .index(indexId)),
+                        title: "留言",
+                        count: index.replies
+                      )
+                    }
+                  }
                   Spacer(minLength: 0)
                 }
               }.font(.callout)
             }
-          }
-
-          if !isolationMode {
-            CommentListNavigationLink(
-              route: CommentListRoute(parent: .index(indexId)),
-              title: "留言",
-              count: index.replies
-            )
           }
 
           if !index.desc.isEmpty {

--- a/App/Views/Person/PersonView.swift
+++ b/App/Views/Person/PersonView.swift
@@ -259,19 +259,21 @@ struct PersonDetailView: View {
         .buttonStyle(.navigation)
         .padding(.vertical, 4)
 
-        Label("\(person.collects)人收藏", systemImage: "heart")
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-          .lineLimit(1)
+        HStack {
+          Label("\(person.collects)人收藏", systemImage: "heart")
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+          Spacer(minLength: 8)
+          if !isolationMode {
+            CommentListNavigationLink(
+              route: CommentListRoute(parent: .person(person.id)),
+              count: person.comment
+            )
+          }
+        }
+        .font(.footnote)
       }.padding(.leading, 2)
     }.frame(height: 120)
-
-    if !isolationMode {
-      CommentListNavigationLink(
-        route: CommentListRoute(parent: .person(person.id)),
-        count: person.comment
-      )
-    }
 
     /// summary
     BBCodeView(person.summary, textSize: 14)


### PR DESCRIPTION
## Summary

Comment links now appear as compact icon-and-count actions within each detail header instead of occupying a separate full-width row. This keeps the entry discoverable while matching the surrounding metadata layout.

Top-level comment sheets now use context-appropriate titles: `添加吐槽` for blog, character, person, and episode comments; `添加留言` for index comments; and `添加回复` for timeline replies. Replies to an existing post continue to identify the target user.

## Validation

- `make build`
