### PR TITLE
feat: add topic age badges

### DIFF
--- a/App/Components/TopicTitleView.swift
+++ b/App/Components/TopicTitleView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct TopicTitleView: View {
+  @AppStorage("showTopicAgeBadge") private var showTopicAgeBadge = true
+
+  let title: String
+  let createdAt: Int
+  let updatedAt: Int
+  let replyCount: Int?
+  let link: String?
+
+  init(
+    title: String,
+    createdAt: Int,
+    updatedAt: Int,
+    replyCount: Int?,
+    link: String? = nil
+  ) {
+    self.title = title
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+    self.replyCount = replyCount
+    self.link = link
+  }
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 4) {
+      if showTopicAgeBadge {
+        if let badge = ActivityBadge.resolve(
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+          replyCount: replyCount ?? 0
+        ) {
+          Text(badge.title)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(badge.color)
+            .padding(.horizontal, 3)
+            .padding(.vertical, 1)
+            .overlay {
+              RoundedRectangle(cornerRadius: 3)
+                .stroke(badge.color, lineWidth: 1)
+            }
+            .padding(.top, 1)
+            .accessibilityLabel(badge.accessibilityLabel)
+        }
+      }
+      Text(title.withLink(link))
+    }
+  }
+}
+
+extension TopicTitleView {
+  private enum ActivityBadge {
+    case newest
+    case newToday
+    case newRecent
+    case grave
+    case oldGrave
+    case ancientGrave
+
+    private static let hour = 60 * 60
+    private static let day = 24 * hour
+    private static let year = 365 * day
+
+    static func resolve(
+      createdAt: Int,
+      updatedAt: Int,
+      replyCount: Int,
+      now: Int = Int(Date.now.timeIntervalSince1970)
+    ) -> Self? {
+      guard createdAt > 0, createdAt <= now else {
+        return nil
+      }
+
+      let topicAge = now - createdAt
+      if topicAge <= 6 * hour {
+        return .newest
+      }
+      if topicAge <= day {
+        return .newToday
+      }
+      if topicAge <= 3 * day {
+        return .newRecent
+      }
+
+      guard
+        replyCount > 0,
+        updatedAt > createdAt,
+        updatedAt <= now,
+        now - updatedAt <= 7 * day
+      else {
+        return nil
+      }
+
+      if topicAge >= 10 * year {
+        return .ancientGrave
+      }
+      if topicAge >= 3 * year {
+        return .oldGrave
+      }
+      if topicAge >= year {
+        return .grave
+      }
+      return nil
+    }
+
+    var title: LocalizedStringResource {
+      switch self {
+      case .newest, .newToday, .newRecent:
+        "新"
+      case .grave, .oldGrave, .ancientGrave:
+        "坟"
+      }
+    }
+
+    var accessibilityLabel: LocalizedStringResource {
+      switch self {
+      case .newest, .newToday, .newRecent:
+        "新帖"
+      case .grave, .oldGrave, .ancientGrave:
+        "坟帖"
+      }
+    }
+
+    var color: Color {
+      switch self {
+      case .newest:
+        .green
+      case .newToday:
+        .teal
+      case .newRecent:
+        .blue
+      case .grave:
+        .indigo
+      case .oldGrave:
+        .brown
+      case .ancientGrave:
+        .gray
+      }
+    }
+  }
+}

--- a/App/Views/Group/GroupTopicListView.swift
+++ b/App/Views/Group/GroupTopicListView.swift
@@ -28,7 +28,12 @@ struct GroupTopicListView: View {
             VStack(alignment: .leading, spacing: 4) {
               HStack {
                 NavigationLink(value: NavDestination.groupTopicDetail(topic.id)) {
-                  Text(topic.title)
+                  TopicTitleView(
+                    title: topic.title,
+                    createdAt: topic.createdAt,
+                    updatedAt: topic.updatedAt,
+                    replyCount: topic.replyCount
+                  )
                     .font(.headline)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)

--- a/App/Views/Group/GroupView.swift
+++ b/App/Views/Group/GroupView.swift
@@ -360,7 +360,12 @@ struct GroupRecentTopicView: View {
             VStack {
               HStack {
                 NavigationLink(value: NavDestination.groupTopicDetail(topic.id)) {
-                  Text(topic.title)
+                  TopicTitleView(
+                    title: topic.title,
+                    createdAt: topic.createdAt,
+                    updatedAt: topic.updatedAt,
+                    replyCount: topic.replyCount
+                  )
                     .font(.callout)
                     .lineLimit(1)
                 }.buttonStyle(.navigation)

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -269,7 +269,13 @@ struct IndexRelatedItemView: View {
                   Image(systemName: item.cat.icon)
                     .foregroundStyle(.secondary)
                     .font(.footnote)
-                  Text(topic.title.withLink(topic.link))
+                  TopicTitleView(
+                    title: topic.title,
+                    createdAt: topic.createdAt,
+                    updatedAt: topic.updatedAt,
+                    replyCount: topic.replyCount,
+                    link: topic.link
+                  )
                     .lineLimit(1)
                   Spacer(minLength: 0)
                 }
@@ -320,7 +326,13 @@ struct IndexRelatedItemView: View {
                   Image(systemName: item.cat.icon)
                     .foregroundStyle(.secondary)
                     .font(.footnote)
-                  Text(topic.title.withLink(topic.link))
+                  TopicTitleView(
+                    title: topic.title,
+                    createdAt: topic.createdAt,
+                    updatedAt: topic.updatedAt,
+                    replyCount: topic.replyCount,
+                    link: topic.link
+                  )
                     .lineLimit(1)
                   Spacer(minLength: 0)
                 }

--- a/App/Views/Rakuen/RakuenGroupTopicView.swift
+++ b/App/Views/Rakuen/RakuenGroupTopicView.swift
@@ -64,10 +64,16 @@ struct RakuenGroupTopicItemView: View {
           .imageType(.avatar)
           .imageLink(topic.link)
         VStack(alignment: .leading) {
-          Section {
-            Text(topic.title.withLink(topic.link))
+          HStack(alignment: .firstTextBaseline, spacing: 2) {
+            TopicTitleView(
+              title: topic.title,
+              createdAt: topic.createdAt,
+              updatedAt: topic.updatedAt,
+              replyCount: topic.replyCount,
+              link: topic.link
+            )
               .font(.headline)
-              + Text("(+\(topic.replyCount))")
+            Text("(+\(topic.replyCount))")
               .font(.footnote)
               .foregroundStyle(.secondary)
           }

--- a/App/Views/Rakuen/RakuenSubjectTopicView.swift
+++ b/App/Views/Rakuen/RakuenSubjectTopicView.swift
@@ -73,10 +73,16 @@ struct RakuenSubjectTopicItemView: View {
           .imageType(.avatar)
           .imageLink(topic.link)
         VStack(alignment: .leading) {
-          Section {
-            Text(topic.title.withLink(topic.link))
+          HStack(alignment: .firstTextBaseline, spacing: 2) {
+            TopicTitleView(
+              title: topic.title,
+              createdAt: topic.createdAt,
+              updatedAt: topic.updatedAt,
+              replyCount: topic.replyCount,
+              link: topic.link
+            )
               .font(.headline)
-              + Text("(+\(topic.replyCount))")
+            Text("(+\(topic.replyCount))")
               .font(.footnote)
               .foregroundStyle(.secondary)
           }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
   @AppStorage("subjectImageQuality") var subjectImageQuality: ImageQuality = .high
   @AppStorage("isolationMode") var isolationMode: Bool = false
   @AppStorage("showNSFWBadge") var showNSFWBadge: Bool = true
+  @AppStorage("showTopicAgeBadge") var showTopicAgeBadge: Bool = true
   @AppStorage("showEpisodeTrends") var showEpisodeTrends: Bool = true
   @AppStorage("hideBlocklist") var hideBlocklist: Bool = false
   @AppStorage("autoCompleteProgress") var autoCompleteProgress: Bool = false
@@ -162,6 +163,10 @@ struct SettingsView: View {
           }
         } label: {
           SettingLabel("回复排序", description: "按发布时间排列话题回复的顺序")
+        }
+
+        Toggle(isOn: $showTopicAgeBadge) {
+          SettingLabel("话题时间标记", description: "在话题列表标题前显示新帖和坟帖标记")
         }
 
         Toggle(isOn: $showSpoilerRelations) {

--- a/App/Views/Subject/SubjectTopicItemView.swift
+++ b/App/Views/Subject/SubjectTopicItemView.swift
@@ -7,7 +7,12 @@ struct SubjectTopicItemView: View {
     CardView {
       VStack(alignment: .leading) {
         NavigationLink(value: NavDestination.subjectTopicDetail(topic.id)) {
-          Text(topic.title)
+          TopicTitleView(
+            title: topic.title,
+            createdAt: topic.createdAt,
+            updatedAt: topic.updatedAt,
+            replyCount: topic.replyCount
+          )
             .font(.callout)
             .multilineTextAlignment(.leading)
         }


### PR DESCRIPTION
## What changed

- Add compact `新` and `坟` badges across subject and group topic lists.
- Use tiered colors for topics created within 6 hours, 24 hours, or 3 days, and for topics older than 1, 3, or 10 years that received a reply within the last 7 days.
- Add a display setting that controls the badges and is enabled by default.

## User experience

Badges use an outlined rounded-square style, align with the first title line, and preserve existing topic links and truncation behavior.

## Validation

- `make build`
