### PR TITLE
fix: add zoom transitions to BBCode image previews

### DIFF
--- a/App/Components/Image+View/ImagePreviewPresenter.swift
+++ b/App/Components/Image+View/ImagePreviewPresenter.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import UIKit
+
+@MainActor
+enum ImagePreviewPresenter {
+  @discardableResult
+  static func present(
+    url: URL,
+    from presentingView: UIView,
+    zoomSourceView: UIView? = nil,
+    onDismiss: (() -> Void)? = nil
+  ) -> Bool {
+    guard
+      let presenter = presentingView.nearestViewController?
+        .topMostPresentedViewController
+    else {
+      onDismiss?()
+      return false
+    }
+
+    let controller = ImagePreviewHostingController(
+      rootView: ImagePreviewer(url: url),
+      onDismiss: onDismiss
+    )
+    controller.modalPresentationStyle = .overFullScreen
+    controller.view.backgroundColor = .clear
+
+    if #available(iOS 18.0, *), let zoomSourceView {
+      controller.preferredTransition = .zoom { [weak zoomSourceView] _ in
+        zoomSourceView
+      }
+    } else {
+      controller.modalTransitionStyle = .crossDissolve
+    }
+
+    presenter.present(controller, animated: true)
+    return true
+  }
+}
+
+@MainActor
+private final class ImagePreviewHostingController: UIHostingController<ImagePreviewer> {
+  private var onDismiss: (() -> Void)?
+
+  init(rootView: ImagePreviewer, onDismiss: (() -> Void)?) {
+    self.onDismiss = onDismiss
+    super.init(rootView: rootView)
+  }
+
+  @available(*, unavailable)
+  dynamic required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+
+    if isBeingDismissed || presentingViewController == nil {
+      finishDismissal()
+    }
+  }
+
+  private func finishDismissal() {
+    onDismiss?()
+    onDismiss = nil
+  }
+}
+
+extension UIView {
+  fileprivate var nearestViewController: UIViewController? {
+    var responder: UIResponder? = self
+    while let current = responder {
+      if let viewController = current as? UIViewController {
+        return viewController
+      }
+      responder = current.next
+    }
+
+    return nil
+  }
+}
+
+extension UIViewController {
+  fileprivate var topMostPresentedViewController: UIViewController {
+    presentedViewController?.topMostPresentedViewController ?? self
+  }
+}

--- a/App/Components/Image+View/ImagePreviewer.swift
+++ b/App/Components/Image+View/ImagePreviewer.swift
@@ -97,7 +97,7 @@ public struct ImagePreviewer: View {
             Button {
               presentShareSheet()
             } label: {
-              Image(systemName: "paperplane")
+              Image(systemName: "square.and.arrow.up")
                 .contentShape(Circle())
             }
             .buttonBorderShape(.circle)

--- a/App/Components/PostDocumentRenderer.swift
+++ b/App/Components/PostDocumentRenderer.swift
@@ -789,7 +789,15 @@ actor PostDocumentRenderer {
 
               if (image) {
                 event.preventDefault();
-                post({ action: 'previewImage', url: image.currentSrc });
+                const rect = image.getBoundingClientRect();
+                post({
+                  action: 'previewImage',
+                  url: image.currentSrc,
+                  x: rect.left,
+                  y: rect.top,
+                  width: rect.width,
+                  height: rect.height,
+                });
               }
             });
 

--- a/App/Components/PostDocumentWebView.swift
+++ b/App/Components/PostDocumentWebView.swift
@@ -9,7 +9,6 @@ enum PostDocumentAction: Equatable {
   case reaction(postID: Int, value: Int)
   case reactionUsers(postID: Int, value: Int)
   case more(postID: Int, anchorY: Double)
-  case previewImage(URL)
 }
 
 struct PostDocumentWebView: UIViewRepresentable {
@@ -111,6 +110,7 @@ struct PostDocumentWebView: UIViewRepresentable {
     private var pendingInitialPostID: Int?
     private var pendingScrollRequest: PostDocumentScrollRequest?
     private var handledScrollRequestID: UUID?
+    private var isPresentingImagePreview = false
 
     init(
       onAction: @escaping (PostDocumentAction) -> Void,
@@ -175,9 +175,16 @@ struct PostDocumentWebView: UIViewRepresentable {
 
       switch message.name {
       case Self.actionMessageName:
-        guard let actionName = payload["action"] as? String,
-          let action = makeAction(name: actionName, payload: payload)
-        else {
+        guard let actionName = payload["action"] as? String else {
+          return
+        }
+
+        if actionName == "previewImage" {
+          presentImagePreview(payload: payload)
+          return
+        }
+
+        guard let action = makeAction(name: actionName, payload: payload) else {
           return
         }
         onAction(action)
@@ -557,16 +564,88 @@ struct PostDocumentWebView: UIViewRepresentable {
           return nil
         }
         return .more(postID: postID, anchorY: anchorY)
-      case "previewImage":
-        guard let rawURL = payload["url"] as? String,
-          let url = URL(string: rawURL),
-          ["http", "https"].contains(url.scheme?.lowercased() ?? "")
-        else {
-          return nil
-        }
-        return .previewImage(url)
       default:
         return nil
+      }
+    }
+
+    private func presentImagePreview(payload: [String: Any]) {
+      guard !isPresentingImagePreview,
+        let webView,
+        let rawURL = payload["url"] as? String,
+        let url = URL(string: rawURL),
+        ["http", "https"].contains(url.scheme?.lowercased() ?? ""),
+        let x = number(payload["x"]),
+        let y = number(payload["y"]),
+        let width = number(payload["width"]),
+        let height = number(payload["height"])
+      else {
+        return
+      }
+
+      isPresentingImagePreview = true
+
+      guard #available(iOS 18.0, *) else {
+        presentImagePreview(url: url, from: webView, zoomSourceView: nil)
+        return
+      }
+
+      let imageFrame = CGRect(x: x, y: y, width: width, height: height)
+        .intersection(webView.bounds)
+      guard !imageFrame.isNull, imageFrame.width > 1, imageFrame.height > 1 else {
+        presentImagePreview(url: url, from: webView, zoomSourceView: nil)
+        return
+      }
+
+      let configuration = WKSnapshotConfiguration()
+      configuration.rect = imageFrame
+      configuration.afterScreenUpdates = false
+      webView.takeSnapshot(with: configuration) { [weak self, weak webView] image, _ in
+        guard let self, let webView else {
+          return
+        }
+
+        guard let image else {
+          self.presentImagePreview(url: url, from: webView, zoomSourceView: nil)
+          return
+        }
+
+        let sourceView = UIImageView(image: image)
+        sourceView.frame = imageFrame
+        sourceView.contentMode = .scaleToFill
+        sourceView.clipsToBounds = true
+        sourceView.isUserInteractionEnabled = false
+        webView.addSubview(sourceView)
+
+        self.presentImagePreview(
+          url: url,
+          from: webView,
+          zoomSourceView: sourceView,
+          onDismiss: {
+            sourceView.removeFromSuperview()
+          }
+        )
+      }
+    }
+
+    private func presentImagePreview(
+      url: URL,
+      from webView: WKWebView,
+      zoomSourceView: UIView?,
+      onDismiss: (() -> Void)? = nil
+    ) {
+      let didPresent = ImagePreviewPresenter.present(
+        url: url,
+        from: webView,
+        zoomSourceView: zoomSourceView,
+        onDismiss: { [weak self] in
+          onDismiss?()
+          self?.isPresentingImagePreview = false
+        }
+      )
+
+      if !didPresent {
+        isPresentingImagePreview = false
       }
     }
 

--- a/App/Features/BBCode/Views/BBCodeUIKitView.swift
+++ b/App/Features/BBCode/Views/BBCodeUIKitView.swift
@@ -715,15 +715,11 @@ private final class BBCodeMediaBlockView: UIView {
   }
 
   private func presentPreview() {
-    guard let presenter = bbcodeNearestViewController()?.bbcodeTopMostPresentedViewController else {
-      return
-    }
-
-    let controller = UIHostingController(rootView: ImagePreviewer(url: media.url))
-    controller.modalPresentationStyle = .overFullScreen
-    controller.modalTransitionStyle = .crossDissolve
-    controller.view.backgroundColor = .clear
-    presenter.present(controller, animated: true)
+    ImagePreviewPresenter.present(
+      url: media.url,
+      from: self,
+      zoomSourceView: imageView
+    )
   }
 }
 
@@ -962,25 +958,5 @@ extension UIStackView {
       removeArrangedSubview(view)
       view.removeFromSuperview()
     }
-  }
-}
-
-extension UIView {
-  fileprivate func bbcodeNearestViewController() -> UIViewController? {
-    var responder: UIResponder? = self
-    while let current = responder {
-      if let viewController = current as? UIViewController {
-        return viewController
-      }
-      responder = current.next
-    }
-
-    return nil
-  }
-}
-
-extension UIViewController {
-  fileprivate var bbcodeTopMostPresentedViewController: UIViewController {
-    presentedViewController?.bbcodeTopMostPresentedViewController ?? self
   }
 }

--- a/App/Views/Comment/CommentListView.swift
+++ b/App/Views/Comment/CommentListView.swift
@@ -57,14 +57,6 @@ private enum CommentListSheet: Identifiable {
   }
 }
 
-private struct CommentImagePreview: Identifiable {
-  let url: URL
-
-  var id: String {
-    url.absoluteString
-  }
-}
-
 private struct CommentListLoadKey: Hashable {
   let route: CommentListRoute
   let isolationMode: Bool
@@ -105,7 +97,6 @@ struct CommentListView: View {
   @State private var showDeleteConfirmation = false
   @State private var reactionRequests = Set<Int>()
   @State private var actionOverlay: PostActionOverlay<CommentPostTarget>?
-  @State private var preview: CommentImagePreview?
 
   init(route: CommentListRoute, timeline: TimelineDTO? = nil) {
     self.route = route
@@ -165,9 +156,6 @@ struct CommentListView: View {
           },
           onMenuAction: handleMenuAction
         )
-      }
-      .fullScreenCover(item: $preview) { preview in
-        ImagePreviewer(url: preview.url)
       }
       .alert(
         "确认删除",
@@ -490,8 +478,6 @@ struct CommentListView: View {
           anchorY: anchorY
         )
       }
-    case .previewImage(let url):
-      preview = CommentImagePreview(url: url)
     }
   }
 

--- a/App/Views/Topic/TopicDetailView.swift
+++ b/App/Views/Topic/TopicDetailView.swift
@@ -315,7 +315,6 @@ struct TopicDetailView: View {
   @State private var showDeleteConfirmation = false
   @State private var reactionRequests = Set<Int>()
   @State private var actionOverlay: PostActionOverlay<TopicPostTarget>?
-  @State private var preview: TopicImagePreview?
 
   private var title: String {
     data?.title ?? "讨论详情"
@@ -354,9 +353,6 @@ struct TopicDetailView: View {
           },
           onMenuAction: handlePostMenuAction
         )
-      }
-      .fullScreenCover(item: $preview) { preview in
-        ImagePreviewer(url: preview.url)
       }
       .alert(
         "确认删除",
@@ -608,8 +604,6 @@ struct TopicDetailView: View {
           )
         }
       }
-    case .previewImage(let url):
-      preview = TopicImagePreview(url: url)
     }
   }
 
@@ -880,14 +874,6 @@ struct TopicDetailView: View {
 private struct TopicReplyPresentation {
   let replies: [ReplyDTO]
   let count: Int
-}
-
-private struct TopicImagePreview: Identifiable {
-  let url: URL
-
-  var id: String {
-    url.absoluteString
-  }
 }
 
 private struct TopicLoadFailureView: View {


### PR DESCRIPTION
## Summary

- add the system zoom transition to native BBCode image previews on iOS 18
- use the tapped HTML image region as the zoom source for WebKit-rendered post and comment pages
- keep the cross-dissolve fallback on earlier iOS versions and use the standard share symbol

Linked images continue to open their destination instead of the image preview.

## Validation

- `make build`
- `git diff --check`
- `swift-format lint --strict App/Components/Image+View/ImagePreviewPresenter.swift`
