### PR TITLE
feat(topic): show inline topic metadata

### DIFF
--- a/App/Components/TopicTitleView.swift
+++ b/App/Components/TopicTitleView.swift
@@ -1,143 +1,91 @@
 import SwiftUI
 
 struct TopicTitleView: View {
+  private static let hour = 60 * 60
+  private static let day = 24 * hour
+  private static let year = 365 * day
+
   @AppStorage("showTopicAgeBadge") private var showTopicAgeBadge = true
 
   let title: String
   let createdAt: Int
-  let updatedAt: Int
   let replyCount: Int?
   let link: String?
+  let showsReplyCount: Bool
 
   init(
     title: String,
     createdAt: Int,
-    updatedAt: Int,
     replyCount: Int?,
-    link: String? = nil
+    link: String? = nil,
+    showsReplyCount: Bool = false
   ) {
     self.title = title
     self.createdAt = createdAt
-    self.updatedAt = updatedAt
     self.replyCount = replyCount
     self.link = link
+    self.showsReplyCount = showsReplyCount
   }
 
   var body: some View {
-    HStack(alignment: .top, spacing: 4) {
-      if showTopicAgeBadge {
-        if let badge = ActivityBadge.resolve(
-          createdAt: createdAt,
-          updatedAt: updatedAt,
-          replyCount: replyCount ?? 0
-        ) {
-          Text(badge.title)
-            .font(.caption)
-            .fontWeight(.semibold)
-            .foregroundStyle(badge.color)
-            .padding(.horizontal, 3)
-            .padding(.vertical, 1)
-            .overlay {
-              RoundedRectangle(cornerRadius: 3)
-                .stroke(badge.color, lineWidth: 1)
-            }
-            .padding(.top, 1)
-            .accessibilityLabel(badge.accessibilityLabel)
-        }
-      }
-      Text(title.withLink(link))
+    let now = Int(Date.now.timeIntervalSince1970)
+    var text = Text(title.withLink(link))
+
+    if showTopicAgeBadge, createdAt > 0, createdAt <= now {
+      let elapsed = now - createdAt
+      text =
+        text
+        + Text(" [\(ageText(elapsed: elapsed))]")
+        .font(.caption)
+        .foregroundColor(ageColor(elapsed: elapsed))
     }
+
+    if showsReplyCount, let replyCount {
+      text =
+        text
+        + Text(" (+\(replyCount))")
+        .font(.footnote)
+        .foregroundColor(.secondary)
+    }
+
+    return text
   }
-}
 
-extension TopicTitleView {
-  private enum ActivityBadge {
-    case newest
-    case newToday
-    case newRecent
-    case grave
-    case oldGrave
-    case ancientGrave
-
-    private static let hour = 60 * 60
-    private static let day = 24 * hour
-    private static let year = 365 * day
-
-    static func resolve(
-      createdAt: Int,
-      updatedAt: Int,
-      replyCount: Int,
-      now: Int = Int(Date.now.timeIntervalSince1970)
-    ) -> Self? {
-      guard createdAt > 0, createdAt <= now else {
-        return nil
-      }
-
-      let topicAge = now - createdAt
-      if topicAge <= 6 * hour {
-        return .newest
-      }
-      if topicAge <= day {
-        return .newToday
-      }
-      if topicAge <= 3 * day {
-        return .newRecent
-      }
-
-      guard
-        replyCount > 0,
-        updatedAt > createdAt,
-        updatedAt <= now,
-        now - updatedAt <= 7 * day
-      else {
-        return nil
-      }
-
-      if topicAge >= 10 * year {
-        return .ancientGrave
-      }
-      if topicAge >= 3 * year {
-        return .oldGrave
-      }
-      if topicAge >= year {
-        return .grave
-      }
-      return nil
+  private func ageText(elapsed: Int) -> String {
+    if elapsed < Self.hour {
+      return "new"
     }
-
-    var title: LocalizedStringResource {
-      switch self {
-      case .newest, .newToday, .newRecent:
-        "新"
-      case .grave, .oldGrave, .ancientGrave:
-        "坟"
-      }
+    if elapsed < Self.day {
+      return "\(elapsed / Self.hour)h"
     }
-
-    var accessibilityLabel: LocalizedStringResource {
-      switch self {
-      case .newest, .newToday, .newRecent:
-        "新帖"
-      case .grave, .oldGrave, .ancientGrave:
-        "坟帖"
-      }
+    if elapsed < 30 * Self.day {
+      return "\(elapsed / Self.day)d"
     }
-
-    var color: Color {
-      switch self {
-      case .newest:
-        .green
-      case .newToday:
-        .teal
-      case .newRecent:
-        .blue
-      case .grave:
-        .indigo
-      case .oldGrave:
-        .brown
-      case .ancientGrave:
-        .gray
-      }
+    if elapsed < Self.year {
+      return "\(elapsed / (30 * Self.day))mo"
     }
+    return "\(elapsed / Self.year)y"
+  }
+
+  private func ageColor(elapsed: Int) -> Color {
+    if elapsed < 6 * Self.hour {
+      return .green
+    }
+    if elapsed < Self.day {
+      return .teal
+    }
+    if elapsed < 3 * Self.day {
+      return .blue
+    }
+    if elapsed < Self.year {
+      return .cyan
+    }
+    if elapsed < 3 * Self.year {
+      return .indigo
+    }
+    if elapsed < 10 * Self.year {
+      return .brown
+    }
+    return .gray
   }
 }

--- a/App/Views/Group/GroupTopicListView.swift
+++ b/App/Views/Group/GroupTopicListView.swift
@@ -31,19 +31,14 @@ struct GroupTopicListView: View {
                   TopicTitleView(
                     title: topic.title,
                     createdAt: topic.createdAt,
-                    updatedAt: topic.updatedAt,
-                    replyCount: topic.replyCount
+                    replyCount: topic.replyCount,
+                    showsReplyCount: true
                   )
                     .font(.headline)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
                 }.buttonStyle(.navigation)
                 Spacer()
-                if topic.replyCount ?? 0 > 0 {
-                  Text("(+\(topic.replyCount ?? 0))")
-                    .font(.footnote)
-                    .foregroundStyle(.orange)
-                }
               }
               Divider()
               HStack {

--- a/App/Views/Group/GroupView.swift
+++ b/App/Views/Group/GroupView.swift
@@ -368,6 +368,7 @@ struct GroupRecentTopicView: View {
                   )
                     .font(.callout)
                     .lineLimit(1)
+                    .truncationMode(.middle)
                 }.buttonStyle(.navigation)
                 Spacer()
               }

--- a/App/Views/Group/GroupView.swift
+++ b/App/Views/Group/GroupView.swift
@@ -363,18 +363,13 @@ struct GroupRecentTopicView: View {
                   TopicTitleView(
                     title: topic.title,
                     createdAt: topic.createdAt,
-                    updatedAt: topic.updatedAt,
-                    replyCount: topic.replyCount
+                    replyCount: topic.replyCount,
+                    showsReplyCount: true
                   )
                     .font(.callout)
                     .lineLimit(1)
                 }.buttonStyle(.navigation)
                 Spacer()
-                if topic.replyCount ?? 0 > 0 {
-                  Text("(+\(topic.replyCount ?? 0))")
-                    .font(.footnote)
-                    .foregroundStyle(.orange)
-                }
               }
               HStack {
                 Text(topic.createdAt.datetimeDisplay)

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -272,7 +272,6 @@ struct IndexRelatedItemView: View {
                   TopicTitleView(
                     title: topic.title,
                     createdAt: topic.createdAt,
-                    updatedAt: topic.updatedAt,
                     replyCount: topic.replyCount,
                     link: topic.link
                   )
@@ -329,7 +328,6 @@ struct IndexRelatedItemView: View {
                   TopicTitleView(
                     title: topic.title,
                     createdAt: topic.createdAt,
-                    updatedAt: topic.updatedAt,
                     replyCount: topic.replyCount,
                     link: topic.link
                   )

--- a/App/Views/Index/IndexRelatedItemView.swift
+++ b/App/Views/Index/IndexRelatedItemView.swift
@@ -276,6 +276,7 @@ struct IndexRelatedItemView: View {
                     link: topic.link
                   )
                     .lineLimit(1)
+                    .truncationMode(.middle)
                   Spacer(minLength: 0)
                 }
                 Text(topic.group.title)
@@ -332,6 +333,7 @@ struct IndexRelatedItemView: View {
                     link: topic.link
                   )
                     .lineLimit(1)
+                    .truncationMode(.middle)
                   Spacer(minLength: 0)
                 }
                 HStack {

--- a/App/Views/Rakuen/RakuenGroupTopicView.swift
+++ b/App/Views/Rakuen/RakuenGroupTopicView.swift
@@ -64,19 +64,14 @@ struct RakuenGroupTopicItemView: View {
           .imageType(.avatar)
           .imageLink(topic.link)
         VStack(alignment: .leading) {
-          HStack(alignment: .firstTextBaseline, spacing: 2) {
-            TopicTitleView(
-              title: topic.title,
-              createdAt: topic.createdAt,
-              updatedAt: topic.updatedAt,
-              replyCount: topic.replyCount,
-              link: topic.link
-            )
-              .font(.headline)
-            Text("(+\(topic.replyCount))")
-              .font(.footnote)
-              .foregroundStyle(.secondary)
-          }
+          TopicTitleView(
+            title: topic.title,
+            createdAt: topic.createdAt,
+            replyCount: topic.replyCount,
+            link: topic.link,
+            showsReplyCount: true
+          )
+            .font(.headline)
           HStack {
             Text(topic.updatedAt.relativeDisplay).monospacedDigit()
               .font(.caption)

--- a/App/Views/Rakuen/RakuenSubjectTopicView.swift
+++ b/App/Views/Rakuen/RakuenSubjectTopicView.swift
@@ -73,19 +73,14 @@ struct RakuenSubjectTopicItemView: View {
           .imageType(.avatar)
           .imageLink(topic.link)
         VStack(alignment: .leading) {
-          HStack(alignment: .firstTextBaseline, spacing: 2) {
-            TopicTitleView(
-              title: topic.title,
-              createdAt: topic.createdAt,
-              updatedAt: topic.updatedAt,
-              replyCount: topic.replyCount,
-              link: topic.link
-            )
-              .font(.headline)
-            Text("(+\(topic.replyCount))")
-              .font(.footnote)
-              .foregroundStyle(.secondary)
-          }
+          TopicTitleView(
+            title: topic.title,
+            createdAt: topic.createdAt,
+            replyCount: topic.replyCount,
+            link: topic.link,
+            showsReplyCount: true
+          )
+            .font(.headline)
           HStack {
             Text(topic.updatedAt.relativeDisplay).monospacedDigit()
               .font(.caption)

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -166,7 +166,7 @@ struct SettingsView: View {
         }
 
         Toggle(isOn: $showTopicAgeBadge) {
-          SettingLabel("话题时间标记", description: "在话题列表标题前显示新帖和坟帖标记")
+          SettingLabel("话题时间标记", description: "在话题列表标题后显示发帖至今的简短时间")
         }
 
         Toggle(isOn: $showSpoilerRelations) {

--- a/App/Views/Subject/SubjectTopicItemView.swift
+++ b/App/Views/Subject/SubjectTopicItemView.swift
@@ -10,7 +10,6 @@ struct SubjectTopicItemView: View {
           TopicTitleView(
             title: topic.title,
             createdAt: topic.createdAt,
-            updatedAt: topic.updatedAt,
             replyCount: topic.replyCount
           )
             .font(.callout)


### PR DESCRIPTION
## Summary

- Keep topic age and reply counts in the same text flow as multiline titles.
- Replace categorical new/grave badges with compact, color-coded creation ages such as `[new]`, `[3h]`, and `[12y]`.
- Preserve the separate last-reply timestamp and update the display setting description.

## Validation

- `make build`
- `git diff --check`
