### PR TITLE
docs: publish AGENTS.md and add appstore-release skill

### DIFF
--- a/.agents/skills/appstore-release/SKILL.md
+++ b/.agents/skills/appstore-release/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: appstore-release
+description: "Run the Bangumi-iOS App Store release workflow. Use when asked to release or publish the next version: create the App Store Connect version for the current development version, write zh-Hans whatsNew, attach the latest VALID build, submit for review, then run make minor and land the next-version-cycle PR through the fork workflow. Also covers verifying the CI-created GitHub Release and build upload."
+---
+
+# Bangumi-iOS App Store Release
+
+Release the current development version to the App Store, then start the next version cycle.
+
+## Key Facts
+
+- App Store Connect app: `Bangumi Riff`, app ID `6499502714`, platform iOS only, primary locale `zh-Hans`. Verify with `asc apps list --name "Bangumi"` before remote changes; the ID can drift.
+- The repo's `MARKETING_VERSION` runs one version ahead of the store. Releasing means submitting the *current* `MARKETING_VERSION` at HEAD (e.g. submit 3.3 while the store sells 3.2), then bumping to the next version.
+- `releaseType` is `MANUAL`: after review approval the user releases it themselves. Never run `asc versions release` unless explicitly asked.
+- CI (`publish.yml`) on push to `main`: any `CURRENT_PROJECT_VERSION` change uploads the HEAD build to ASC; a minor transition (`X.Y` -> `X.Y+1`) additionally creates the GitHub Release `vX.Y` at the pre-bump commit. GitHub Releases carry no IPA artifacts.
+- `main` on `bangumi/Bangumi-iOS` is protected (required check `Build iOS`). Direct pushes are rejected; version bumps land through the fork PR workflow in AGENTS.md.
+
+## Guardrails
+
+- Work from a clean git state; `make minor`/`make bump` require it and must own all version mutations. Never edit `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` manually.
+- Do not create duplicate ASC versions; reuse an existing editable version in `PREPARE_FOR_SUBMISSION`.
+- Stop before submission if the build is not `VALID` or metadata is incomplete.
+- Submission to review is externally visible; confirm the user asked to release before `submissions-submit`.
+- Keep release notes user-facing: exclude bump commits, CI, refactors, file/class names.
+- Use `gh pr create --body-file`; never pass Markdown bodies inline.
+
+## Phase 1: Determine What To Release
+
+```bash
+git fetch upstream && git status -sb
+grep -m1 MARKETING_VERSION Bangumi.xcodeproj/project.pbxproj
+grep -m1 CURRENT_PROJECT_VERSION Bangumi.xcodeproj/project.pbxproj
+asc versions list --app 6499502714 --platform IOS --pretty   # find READY_FOR_SALE version
+asc builds list --app 6499502714 --pretty                    # latest builds and states
+```
+
+The release target is the repo's current `MARKETING_VERSION` with the latest ASC build whose build number matches `CURRENT_PROJECT_VERSION` at HEAD. If ASC already has that build but no version object, the previous cycle ended right after the bump — proceed to submit it.
+
+## Phase 2: Create Or Reuse The ASC Version
+
+```bash
+asc versions list --app 6499502714 --version "$version" --platform IOS --pretty
+asc versions create --app 6499502714 --version "$version" --platform IOS --pretty   # only if missing
+```
+
+Record the version ID. State must be `PREPARE_FOR_SUBMISSION` before metadata/build changes.
+
+## Phase 3: Write whatsNew (zh-Hans)
+
+1. Read the *previous* released version's whatsNew via `asc localizations list --version <prev_version_id> --pretty` — both as style reference and to find which commits it already covered (it may describe commits after the previous bump).
+2. Draft notes from the uncovered commits up to HEAD. Read full commit bodies, not only subjects.
+3. Follow the established structure: `新功能` / `改进` / `修复` sections with `- ` bullets, concise Chinese, user-facing phrasing.
+4. Update, preserving everything else (description, keywords, URLs stay unchanged unless the user asks):
+
+```bash
+asc localizations update --version "$version_id" --locale zh-Hans --whats-new "$notes" --pretty
+```
+
+`--version` takes the *version* ID, not the localization ID. Read the localization back and confirm `description` is unchanged and `whatsNew` matches the draft.
+
+## Phase 4: Attach Build And Submit
+
+```bash
+asc builds list --app 6499502714 --pretty   # confirm target build is VALID, usesNonExemptEncryption=false
+asc versions attach-build --version-id "$version_id" --build "$build_id" --pretty
+asc versions view --version-id "$version_id" --include-build --pretty   # `get` was removed; use `view`
+```
+
+Submit:
+
+```bash
+submission_id=$(asc review submissions-create --app 6499502714 --platform IOS --pretty \
+  | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data.get("id") or data["data"]["id"])')
+asc review items-add --submission "$submission_id" --item-type appStoreVersions --item-id "$version_id" --pretty
+asc review submissions-submit --id "$submission_id" --confirm --pretty
+```
+
+Verify `asc versions view` reports `WAITING_FOR_REVIEW`. Remind the user that release after approval is manual and theirs to trigger.
+
+## Phase 5: Start The Next Version Cycle
+
+From clean, synced `main`:
+
+```bash
+fork_owner=$(git remote get-url origin | sed -E 's#(git@github\.com:|https://github\.com/)([^/]+)/.*#\2#')
+git switch -c "release/bump-$next_version"
+make minor        # creates commit "chore: bump version to $next_version"
+git push -u origin "release/bump-$next_version"
+gh pr create --repo bangumi/Bangumi-iOS --base main --head "${fork_owner}:release/bump-$next_version" \
+  --title "chore: bump version to $next_version" --body-file /tmp/pr-body.md
+gh pr view <PR> --json url,title,body,headRefName,baseRefName,state,statusCheckRollup
+gh pr view <PR> --json commits,files    # scope: exactly one commit, only project.pbxproj
+```
+
+Wait for `Build iOS` to pass, then squash-merge and resync. The squash merge produces a *new* commit hash on upstream, so reset local `main` instead of pulling:
+
+```bash
+gh pr merge <PR> --repo bangumi/Bangumi-iOS --squash --delete-branch \
+  --subject "chore: bump version to $next_version" --body "..."
+git fetch --prune origin && git fetch --prune upstream
+git switch main
+git diff HEAD upstream/main --stat    # must be empty (same content, different hash)
+git reset --hard upstream/main && git push origin main
+git branch -d "release/bump-$next_version"
+```
+
+## Phase 6: Verify Automation
+
+```bash
+gh release view "v$version" --repo bangumi/Bangumi-iOS --json tagName,targetCommitish,url
+gh run list --repo bangumi/Bangumi-iOS --workflow publish.yml --limit 2 \
+  --json status,conclusion,headSha
+```
+
+- GitHub Release `v$version` must exist, targeting the pre-bump commit.
+- The publish run for the merge commit must end `success` (detect / release / upload jobs).
+- Confirm the new build appears on ASC (`asc builds list`); it can take a few minutes after the upload job succeeds. The new cycle's build does not need an ASC version object until the next release.
+
+## Final Report
+
+- ASC: version ID, build ID, submission ID, final state (`WAITING_FOR_REVIEW`).
+- whatsNew text submitted.
+- Next-cycle PR URL and merge status; GitHub Release URL and target commit.
+- Current local branch, HEAD, and worktree cleanliness.

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ Package.resolved
 
 .vscode/
 .claude/
-AGENTS.md
 
 misc/exportOptions.plist
 archives/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,135 @@
+# AGENTS.md
+
+This file provides repository-specific guidance for coding agents working in
+this repository.
+
+## Project Overview
+
+- Bangumi-iOS is a SwiftUI iOS app using Swift 6, GRDB, and Xcode.
+- The main app target is `Bangumi` in `Bangumi.xcodeproj`.
+- `BBCode/` is a local Swift package used by the app for BBCode rendering.
+- The app is distributed as `Bangumi Riff` in App Store Connect.
+
+## Workflow Rules
+
+- Communicate with the user in Simplified Chinese by default.
+- Keep code, comments, identifiers, commit messages, PR titles, and Markdown code blocks in English.
+- Do not run `make format` in this repository unless the user explicitly asks for it. If formatting is needed, keep it local to the touched code.
+- Prefer small, reviewable changes that match existing SwiftUI and GRDB patterns.
+- Do not include incidental `Bangumi.xcodeproj/project.pbxproj` changes in a PR unless the user asked for a version/build bump or the project file change is truly required.
+- Do not use unsafe language features, unsafe concurrency bypasses, or unsafe runtime assumptions anywhere in this repository. This is a hard global requirement. In Swift, this includes `unsafe` APIs, `nonisolated(unsafe)`, `MainActor.assumeIsolated`, unchecked actor isolation workarounds, and similar constructs.
+- In non-SQL code, do not use unconstrained interpolated literals inside `map` or `compactMap` followed by `joined()`. GRDB may infer the element type as `SQL` and leak `SQL(elements: ...)` descriptions into rendered output. Extract interpolated fragments into a helper that explicitly returns `String`, or append them to a typed `String` accumulator.
+
+## Storage And Migration Rules
+
+- Persistent storage is backed by GRDB. Do not reintroduce SwiftData storage unless the user explicitly asks for it.
+- SwiftData references should stay limited to the one-time legacy import path, such as `LegacySwiftDataMigrator`, old schema definitions, and the old SwiftData migration plan.
+- Keep schema setup and migrations centralized in `DatabaseFactory` with `DatabaseMigrator`.
+- Once a migration has shipped, treat its registered name and body as append-only history. Do not rename, remove, reorder, or rewrite old migrations.
+- For every persistent table, column, index, constraint, or stored payload format change, add a new descriptive `registerMigration(...)` after existing migrations.
+- New non-null columns must either have a safe default or be introduced as nullable and backfilled before enforcing non-null behavior.
+- For SQLite changes that cannot be expressed safely with `ALTER TABLE`, create a replacement table, copy data explicitly, recreate indexes and foreign keys, then drop/rename inside the migration.
+- Treat BLOB or JSON payload shape changes as schema changes. Prefer backward-compatible decoders; otherwise migrate the payloads explicitly or clear only cache tables that are safe to rebuild from the network.
+- Validate storage changes with both a fresh database path and an upgraded existing database path, then run `make build`.
+
+### GRDB Migration Discipline
+
+Runtime GRDB migrations in `DatabaseFactory` are historical artifacts and must be treated as immutable once committed.
+
+- Do not mutate already-registered GRDB migrations such as `createGRDBSchemaV1` or `createLocalMigrationMarkers` to add new columns, defaults, indexes, or table shape changes.
+- Do not treat helper methods called from baseline migrations, such as `createSubjects` or `createSimpleCaches`, as current-schema builders. They define the frozen baseline for that migration.
+- Any GRDB table shape change must be added as a new numbered migration after the latest registered migration. Fresh installs should reach the latest schema by running the baseline migration plus every later migration in order.
+- When adding a new persisted field to a GRDB record, update the runtime record model and `CodingKeys` if present, then add a new migration that backfills a safe default for existing databases.
+- Validate both upgrade and fresh install paths: an existing `Bangumi.sqlite` must migrate forward, and a new empty database must run all migrations without duplicate-column or missing-column failures.
+
+## Client Architecture Rules
+
+- Keep `APIClient` as the low-level HTTP/session/token client only. Do not add feature-specific business APIs, database loading, Spotlight indexing, UI state, or app runtime state to it.
+- Put remote API operations in focused `*Service` types. Put operations that combine remote API calls with local GRDB writes, cache updates, or indexing in focused `*Repository` types.
+- Views and components should call services, repositories, `AuthService`, `AppContext`, or other narrow app services. They should not call `APIClient.shared` directly.
+- Keep `UserDefaults` access centralized in `AppConfig` using typed static properties. Avoid new raw `UserDefaults.standard` calls outside that boundary; `@AppStorage` remains acceptable in SwiftUI views when it is the local view binding mechanism.
+- App runtime state such as the GRDB `DatabaseOperator` and app version display should live behind `AppContext` / `AppMetadata`, not in `APIClient`.
+- Device and platform metadata that requires main-actor-safe setup should be initialized from an explicit `@MainActor` setup path, such as `MainApp.init`. Never bypass actor isolation for convenience.
+- For User-Agent device model values, prefer a safe platform helper approach such as `uname(&utsname)` during main-actor setup, then cache the resulting string in `AppConfig`.
+
+## Common Commands
+
+```sh
+make build
+make bump
+make release-ios
+make artifact-ios
+```
+
+Command notes:
+
+- `make build` builds the app for iOS simulator and runs `ensure-config`.
+- Do not call `xcodebuild` directly for normal validation; use `make build` instead.
+- `make bump` increments `CURRENT_PROJECT_VERSION` and creates a standalone commit like `chore: incr build ver to <n>`. It commits only `Bangumi.xcodeproj/project.pbxproj`.
+- `make major` / `make minor` increment `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` together. Do not edit either version manually in `project.pbxproj`; use the Makefile targets.
+- Release automation treats build upload and GitHub Release creation separately:
+  - Any `CURRENT_PROJECT_VERSION` change uploads the current HEAD build to App Store Connect.
+  - A major transition such as `1.13 -> 2.0` uploads the `2.0` build but does not create a GitHub Release.
+  - A same-major minor transition such as `2.0 -> 2.1` creates the GitHub Release for the previous marketing version (`v2.0`) at the previous commit, while the HEAD build can continue uploading as `2.1`.
+  - GitHub Releases do not upload IPA artifacts.
+- For BBCode package changes, still prefer the repository-provided build entrypoint first. Only use lower-level Xcode commands when the user explicitly asks or when `make build` cannot answer the specific failure.
+
+## GitHub And PR Rules
+
+- This repo is a fork workflow:
+  - `origin` is the contributor's own fork
+  - the upstream/default GitHub repo is `bangumi/Bangumi-iOS`
+- For PRs to upstream, push a branch to the fork and use:
+
+```sh
+gh pr create --repo bangumi/Bangumi-iOS --base main --head '<fork-owner>:<branch>' --title '<semantic title>' --body-file /tmp/pr-body.md
+```
+
+- Always use `--body-file` for PR descriptions.
+- After creating a PR, verify both metadata and scope:
+
+```sh
+gh pr view <number> --json url,title,body,headRefName,baseRefName
+gh pr view <number> --json commits,files
+```
+
+- A PR is not done until the commit list and file list match the user-requested scope.
+- Avoid zsh empty-glob failures when looking for PR templates. Prefer `find` or a shell with `nullglob` instead of raw `.github/PULL_REQUEST_TEMPLATE/*.md`.
+- If the user says "提个 PR" or similar, complete branch creation, commit, push, PR creation, and post-create scope verification unless they explicitly ask to stop earlier.
+- If the user also asks for `make bump`, keep the bump as its own commit.
+
+## SwiftUI UI Rules
+
+- Use SwiftUI-first implementations unless the existing local code path is UIKit-based.
+- Do not use `HStack` inside a toolbar. Group adjacent toolbar actions with `ToolbarItemGroup` at the appropriate placement.
+- Do not put live persistent models directly into `NavigationPath` / `NavigationLink(value:)` values. Use stable IDs or explicit value snapshots instead; live models can make SwiftUI navigation hashing/diffing unstable across OS releases.
+- Prefer system button sizing and styles. Avoid hand-written frames, font overrides, foreground colors, or wrapper views unless they are needed for hit testing or platform behavior.
+- Keep SwiftUI animation ownership explicit: use `.animation(_:value:)` for local micro-interactions such as button press, hover, selection highlight, or compact control state only.
+- Use `withAnimation` at the state mutation point for state transitions such as sheets, navigation-affecting state, list/content replacement, filter or sort changes, and page mode switches.
+- For complex screens, prefer explicit animation in actions, async reload completion, or binding setters instead of scattering `.animation(_:value:)` across parent view modifiers.
+- Preserve scroll performance by animating first-page/reload content replacement only when it improves continuity; avoid animating infinite-scroll append paths unless the interaction explicitly calls for it.
+- For fixed-size badges, chips, and compact counters, do not use `.minimumScaleFactor(...)` or `.allowsTightening(true)` to hide layout pressure. These can cause the same UI element to render at different visual sizes across layout passes.
+- Do not add `.fixedSize(horizontal: true, vertical: false)` to compact labels unless overflow has been considered. It can preserve font size but may expand beyond the intended layout for unexpectedly long text.
+- For episode badges, keep the inherited font size stable; if text is too long, prefer normal one-line truncation/clipping behavior over per-item font scaling.
+- VoiceOver support is out of scope for this app. Do not add VoiceOver-specific labels, traits, actions, or layout workarounds unless the user explicitly asks for them.
+
+## BBCode And Image Preview Rules
+
+- BBCode image rendering flows through:
+  - `BBCode/Sources/BBCode/Renders/PreparedDocument.swift`
+  - `BBCode/Sources/BBCode/Views/BBCodeUIKitView.swift`
+- When fixing image alignment, preserve the asset's natural visual size. Do not solve centering by making all images full width.
+- Thumbnail/downsample logic must not upscale small images.
+- Treat vector/unconstrained SVG images carefully; avoid forcing them through raster thumbnail paths that expand them to container width.
+- For image preview sharing, prefer directly presenting `UIActivityViewController` from UIKit when the existing code path is UIKit-based.
+- Share sheet previews should provide image data and `LPLinkMetadata` when needed; sharing only a URL can produce empty previews and miss save-image behavior.
+- In image preview controls, prefer native system control styling. Keep only minimal shape or hit-area constraints such as circular button shape when needed.
+
+## App Store Connect Release Notes
+
+- For ASC release tasks, do not assume app IDs, version IDs, or locale IDs. Query the current App Store Connect state first.
+- The app ID previously used for `Bangumi Riff` was `6499502714`, with primary locale `zh-Hans`; verify before acting because this can drift.
+- If the user says `desc 不变`, copy or preserve the previous version description and related metadata.
+- When generating release notes, inspect full commit bodies, not only commit subjects.
+- If the user says to follow the previous changelog style, use the existing Chinese structure such as `新功能 / 改进 / 修复` when it matches the previous version.
+- After creating or updating ASC metadata, read it back and confirm that `description` stayed unchanged and `whatsNew` was updated.


### PR DESCRIPTION
## Problem

The repository's agent guidance in `AGENTS.md` was gitignored, so contributors and coding agents cloning the repo never saw it. The App Store release workflow also lived only in local knowledge.

## Approach

- Remove `AGENTS.md` from `.gitignore` and publish it, generalizing contributor-specific wording (local paths, fork owner, branch prefix conventions) so it applies to any contributor.
- Add a project-level `.agents/skills/appstore-release` skill documenting the full release workflow: determining the version to release, creating/reusing the App Store Connect version, writing zh-Hans `whatsNew` in the established style, attaching the VALID build, submitting for review, then starting the next version cycle via `make minor` and the fork PR flow, including the post-squash local `main` resync.

## Validation

- [x] Reviewed AGENTS.md for contributor-specific content
- [x] Followed the documented workflow end-to-end for the 3.3 release
