### PR TITLE
feat: tolerate comment user/creator key rename

### DIFF
--- a/App/Client/Types.swift
+++ b/App/Client/Types.swift
@@ -894,6 +894,69 @@ struct CommentDTO: Codable, Identifiable, Hashable {
   var reactions: [ReactionDTO]?
 }
 
+/// Decode keys shared by the tolerant comment decoders below.
+///
+/// The server currently sends `user` on comment payloads; a planned
+/// server-side change renames it to `creator`. Accepting both keys keeps
+/// decoding working across the transition.
+private enum CommentDecodeKeys: String, CodingKey {
+  case id
+  case content
+  case createdAt
+  case creatorID
+  case mainID
+  case relatedID
+  case state
+  case user
+  case creator
+  case replies
+  case reactions
+}
+
+extension CommentBaseDTO {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CommentDecodeKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    content = try container.decode(String.self, forKey: .content)
+    createdAt = try container.decode(Int.self, forKey: .createdAt)
+    creatorID = try container.decode(Int.self, forKey: .creatorID)
+    mainID = try container.decode(Int.self, forKey: .mainID)
+    relatedID = try container.decode(Int.self, forKey: .relatedID)
+    state = try container.decode(PostState.self, forKey: .state)
+    user = try container.decodeIfPresent(SlimUserDTO.self, forKey: .user)
+      ?? container.decodeIfPresent(SlimUserDTO.self, forKey: .creator)
+    reactions = try container.decodeIfPresent([ReactionDTO].self, forKey: .reactions)
+  }
+}
+
+extension CommentDTO {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CommentDecodeKeys.self)
+    id = try container.decode(Int.self, forKey: .id)
+    content = try container.decode(String.self, forKey: .content)
+    createdAt = try container.decode(Int.self, forKey: .createdAt)
+    creatorID = try container.decode(Int.self, forKey: .creatorID)
+    mainID = try container.decode(Int.self, forKey: .mainID)
+    relatedID = try container.decode(Int.self, forKey: .relatedID)
+    state = try container.decode(PostState.self, forKey: .state)
+    if let user = try container.decodeIfPresent(SlimUserDTO.self, forKey: .user) {
+      self.user = user
+    } else if let creator = try container.decodeIfPresent(SlimUserDTO.self, forKey: .creator) {
+      self.user = creator
+    } else {
+      throw DecodingError.keyNotFound(
+        CommentDecodeKeys.user,
+        DecodingError.Context(
+          codingPath: container.codingPath,
+          debugDescription: "Expected `user` or `creator` in comment payload"
+        )
+      )
+    }
+    replies = try container.decode([CommentBaseDTO].self, forKey: .replies)
+    reactions = try container.decodeIfPresent([ReactionDTO].self, forKey: .reactions)
+  }
+}
+
 struct SubjectRelationDTO: Codable, Identifiable, Hashable {
   var order: Int
   var subject: SlimSubjectDTO


### PR DESCRIPTION
## Summary

Add tolerant decoding for comment payloads ahead of a planned server-side
breaking change announced in bangumi/server-private#1780: the `user` field on
comment (`Comment` / `CommentBase`) responses will be renamed to `creator` in
a follow-up step.

- `CommentDTO` and `CommentBaseDTO` now decode `user` first and fall back to
  `creator`, so the transition does not break comment list decoding
  (`CommentDTO.user` is non-optional; a missing key would otherwise throw).
- Custom `init(from:)` implementations live in extensions, keeping the
  synthesized memberwise initializer and `encode(to:)` (encoding still
  writes `user`) untouched.
- No behavioral change against the current API.

Once the server rename ships and the old key is removed, this compatibility
layer can be simplified or dropped.

## Tests

- `make build`: pass
