### PR TITLE
fix: adapt progress recent episodes row for small screens and long series

### DIFF
--- a/App/Views/Episode/EpisodeRecentView.swift
+++ b/App/Views/Episode/EpisodeRecentView.swift
@@ -53,7 +53,15 @@ struct EpisodeRecentView: View {
   }
 
   var recentCount: Int {
-    5
+    let maxDisplayWidth = episodes.map { $0.sort.episodeDisplay.count }.max() ?? 0
+    switch maxDisplayWidth {
+    case 4...:
+      return 3
+    case 3:
+      return 4
+    default:
+      return 5
+    }
   }
 
   private var recentEpisodes: RecentEpisodes {
@@ -121,87 +129,80 @@ struct EpisodeRecentView: View {
     return min(Double(subject.interest?.epStatus ?? 0) / Double(subject.eps), 1)
   }
 
+  @ViewBuilder
+  private func recentBadges(_ recent: RecentEpisodes) -> some View {
+    HStack(spacing: 2) {
+      ForEach(recent.episodes) { episode in
+        EpisodeItemView(
+          episode: episode,
+          interactionMode: interactionMode,
+          subjectCollectionType: subject.ctypeEnum,
+          reload: reload
+        )
+      }
+    }
+    .font(.footnote)
+  }
+
+  @ViewBuilder
+  private func nextAction(_ recent: RecentEpisodes, fillWidth: Bool) -> some View {
+    if let episode = recent.nextEpisode {
+      EpisodeNextView(episode: episode, fillWidth: fillWidth, progress: progressFraction, reload: reload)
+    } else {
+      Button {
+        showCollectionBox = true
+      } label: {
+        HStack(spacing: 4) {
+          if fillWidth {
+            Spacer()
+          }
+          Text(progressText)
+          Image(systemName: progressIcon)
+          if fillWidth {
+            Spacer()
+          }
+        }
+        .foregroundStyle(.linkText)
+        .progressActionLabelStyle(.standaloneSubtle)
+        .progressActionFill(progressFraction)
+      }
+      .progressActionButtonStyle(tint: .secondary)
+      .sheet(isPresented: $showCollectionBox) {
+        SubjectCollectionBoxView(subjectId: subject.id, initialSubject: subject)
+          .onDisappear {
+            Task {
+              await reload?()
+            }
+          }
+      }
+    }
+  }
+
   var body: some View {
     let recent = recentEpisodes
     if !recent.episodes.isEmpty {
       switch mode {
       case .tile:
         VStack {
-          HStack(spacing: 2) {
-            ForEach(recent.episodes) { episode in
-              EpisodeItemView(
-                episode: episode,
-                interactionMode: interactionMode,
-                subjectCollectionType: subject.ctypeEnum,
-                reload: reload
-              )
-            }
+          HStack {
+            recentBadges(recent)
             Spacer(minLength: 0)
           }
-          .font(.footnote)
-          if let episode = recent.nextEpisode {
-            EpisodeNextView(episode: episode, fillWidth: true, progress: progressFraction, reload: reload)
-          } else {
-            Button {
-              showCollectionBox = true
-            } label: {
-              HStack(spacing: 4) {
-                Spacer()
-                Text(progressText)
-                Image(systemName: progressIcon)
-                Spacer()
-              }
-              .foregroundStyle(.linkText)
-              .progressActionLabelStyle(.standaloneSubtle)
-              .progressActionFill(progressFraction)
-            }
-            .progressActionButtonStyle(tint: .secondary)
-            .sheet(isPresented: $showCollectionBox) {
-              SubjectCollectionBoxView(subjectId: subject.id, initialSubject: subject)
-                .onDisappear {
-                  Task {
-                    await reload?()
-                  }
-                }
-            }
-          }
+          nextAction(recent, fillWidth: true)
         }
       case .list:
-        HStack(alignment: .bottom) {
-          HStack(spacing: 2) {
-            ForEach(recent.episodes) { episode in
-              EpisodeItemView(
-                episode: episode,
-                interactionMode: interactionMode,
-                subjectCollectionType: subject.ctypeEnum,
-                reload: reload
-              )
+        ViewThatFits(in: .horizontal) {
+          HStack(alignment: .bottom) {
+            recentBadges(recent)
+            Spacer(minLength: 0)
+            nextAction(recent, fillWidth: false)
+          }
+          VStack(alignment: .leading, spacing: 4) {
+            HStack {
+              recentBadges(recent)
+              Spacer(minLength: 0)
             }
-          }.font(.footnote)
-          Spacer(minLength: 0)
-          if let episode = recent.nextEpisode {
-            EpisodeNextView(episode: episode, fillWidth: false, progress: progressFraction, reload: reload)
-          } else {
-            Button {
-              showCollectionBox = true
-            } label: {
-              HStack(spacing: 4) {
-                Text(progressText)
-                Image(systemName: progressIcon)
-              }
-              .foregroundStyle(.linkText)
-              .progressActionLabelStyle(.standaloneSubtle)
-              .progressActionFill(progressFraction)
-            }
-            .progressActionButtonStyle(tint: .secondary)
-            .sheet(isPresented: $showCollectionBox) {
-              SubjectCollectionBoxView(subjectId: subject.id, initialSubject: subject)
-                .onDisappear {
-                  Task {
-                    await reload?()
-                  }
-                }
-            }
+            nextAction(recent, fillWidth: true)
           }
         }
       }
@@ -318,6 +319,7 @@ private struct EpisodeNextLabel: View {
 
   var body: some View {
     Label(desc, systemImage: icon)
+      .lineLimit(1)
       .foregroundStyle(isEnabled ? .linkText : .secondary)
   }
 }


### PR DESCRIPTION
## Problem

On narrow devices (e.g. iPhone SE, 375pt), the progress page list row breaks for long-running series with hundreds or thousands of episodes:

- the fixed window of 5 episode badges is too wide once episode numbers reach 3-4 digits, so badges get compressed and truncate ("1...")
- the next-episode button ("EP.187 ~ 5 天后") has no line limit, so its label wraps onto two lines and collides with the badge row

## Approach

- Size the recent-episode window by the episode number display width: 5 badges for 1-2 digit numbers, 4 for 3 digits, 3 for 4+ digits or decimal sorts (e.g. "12.5"). This keeps the single-line row within the available width on small screens and also relieves the narrower tiles in tile mode.
- Wrap the list-mode row in `ViewThatFits`: keep the existing single-line layout when it fits, otherwise fall back to a stacked layout (badges row above a full-width action button), matching what tile mode already looks like.
- Pin `EpisodeNextLabel` to a single line so its measured width is honest (a wrappable label would always "fit") and it can never wrap mid-row; in the worst case it truncates on one line instead.
- Extract the badges row and the action button into shared helpers used by both tile and list modes.

## Validation

- `make build` passes.
